### PR TITLE
Parameter Validation Developed

### DIFF
--- a/backend/json_classes.py
+++ b/backend/json_classes.py
@@ -1,5 +1,6 @@
 from typing import Optional
-from pydantic import BaseModel
+from pydantic import BaseModel, Field
+import regex
 
 
 class Success(BaseModel):
@@ -105,8 +106,24 @@ class Account(BaseModel):
 
 
 class UserCreate(BaseModel):
-    email: str
-    password: str
+    email: str = Field(
+        ...,
+        pattern=regex.compile(
+            r"^(?=.{1,254}$)(?=.{1,64}@)(?!.*\.\.)"
+            r"[a-zA-Z0-9](?:[a-zA-Z0-9._%+-]{0,62}[a-zA-Z0-9])?"
+            r"@"
+            r"(?:[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?\.)+"
+            r"[A-Za-z]{2,}$"
+        ),
+        description="Email must be in a correct format",
+    )
+    password: str = Field(
+        ...,
+        pattern=regex.compile(
+            r"^(?=.*\d)(?=.*\p{L})(?=.*[^\p{L}\p{N}\s]).{8,}$"
+        ),
+        description="Password should have at least 8 symbols and contain digits, letters, and special symbols",
+    )
     name: str
 
 

--- a/backend/json_classes.py
+++ b/backend/json_classes.py
@@ -106,24 +106,8 @@ class Account(BaseModel):
 
 
 class UserCreate(BaseModel):
-    email: str = Field(
-        ...,
-        pattern=regex.compile(
-            r"^(?=.{1,254}$)(?=.{1,64}@)(?!.*\.\.)"
-            r"[a-zA-Z0-9](?:[a-zA-Z0-9._%+-]{0,62}[a-zA-Z0-9])?"
-            r"@"
-            r"(?:[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?\.)+"
-            r"[A-Za-z]{2,}$"
-        ),
-        description="Email must be in a correct format",
-    )
-    password: str = Field(
-        ...,
-        pattern=regex.compile(
-            r"^(?=.*\d)(?=.*\p{L})(?=.*[^\p{L}\p{N}\s]).{8,}$"
-        ),
-        description="Password should have at least 8 symbols and contain digits, letters, and special symbols",
-    )
+    email: str
+    password: str
     name: str
 
 

--- a/backend/logic/users.py
+++ b/backend/logic/users.py
@@ -39,6 +39,15 @@ def create_user(db_conn, db_cursor, user):
         and len(user.email.split("@")[0]) <= 64
     ):
         raise HTTPException(status_code=400, detail="Incorrect email format")
+    
+    # validation of username format
+    pattern=r"^[\p{L}0-9_ ]+$"
+    if not (
+        match(pattern, user.name)
+        and 1 <= len(user.name) <= 80
+        and not(user.name[0].isdigit())
+    ):
+        raise HTTPException(status_code=400, detail="Incorrect name format")
 
     # validation of password complexity (length, digit(s), letter(s), special symbol(s))
     if not (

--- a/backend/logic/users.py
+++ b/backend/logic/users.py
@@ -30,6 +30,25 @@ def get_user_role(db_cursor, course_id: str, user_email: str):
 
 def create_user(db_conn, db_cursor, user):
 
+    # validation of email format
+    pattern = r"^[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,}$"
+    if not (
+        match(pattern, user.email)
+        and len(user.email) <= 254
+        and not ".." in user.email
+        and len(user.email.split("@")[0]) <= 64
+    ):
+        raise HTTPException(status_code=400, detail="Incorrect email format")
+
+    # validation of password complexity (length, digit(s), letter(s), special symbol(s))
+    if not (
+        len(user.password) >= 8
+        and search(r"\d", user.password)
+        and search(r"\p{L}", user.password)
+        and search(r"[^\p{L}\p{N}\s]", user.password)
+    ):
+        raise HTTPException(status_code=400, detail="Password is too weak")
+
     # checking whether such user exists
     user_exists = repo_users.sql_select_user_exists(db_cursor, user.email)
     if user_exists:

--- a/backend/logic/users.py
+++ b/backend/logic/users.py
@@ -30,25 +30,6 @@ def get_user_role(db_cursor, course_id: str, user_email: str):
 
 def create_user(db_conn, db_cursor, user):
 
-    # validation of email format
-    pattern = r"^[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,}$"
-    if not (
-        match(pattern, user.email)
-        and len(user.email) <= 254
-        and not ".." in user.email
-        and len(user.email.split("@")[0]) <= 64
-    ):
-        raise HTTPException(status_code=400, detail="Incorrect email format")
-
-    # validation of password complexity (length, digit(s), letter(s), special symbol(s))
-    if not (
-        len(user.password) >= 8
-        and search(r"\d", user.password)
-        and search(r"\p{L}", user.password)
-        and search(r"[^\p{L}\p{N}\s]", user.password)
-    ):
-        raise HTTPException(status_code=400, detail="Password is too weak")
-
     # checking whether such user exists
     user_exists = repo_users.sql_select_user_exists(db_cursor, user.email)
     if user_exists:

--- a/backend/logic/users.py
+++ b/backend/logic/users.py
@@ -42,6 +42,7 @@ def create_user(db_conn, db_cursor, user):
     
     # validation of username format
     pattern=r"^[\p{L}0-9_ ]+$"
+    user.name = user.name.strip()
     if not (
         match(pattern, user.name)
         and 1 <= len(user.name) <= 80

--- a/backend/routers/assignments.py
+++ b/backend/routers/assignments.py
@@ -1,5 +1,5 @@
 from typing import List
-from fastapi import APIRouter, Depends, UploadFile, File
+from fastapi import APIRouter, Depends, Query, UploadFile, File
 from auth import get_current_user, get_db, get_storage_db
 import json_classes
 import logic.assignments
@@ -11,12 +11,29 @@ router = APIRouter()
 @router.post("/create_assignment", response_model=json_classes.AssignmentID, tags=["Assignments"])
 async def create_assignment(
     course_id: str,
-    title: str,
-    description: str,
+    title: str = Query(
+        ...,
+        min_length=3,
+        max_length=80,
+        pattern=r"^[\p{L}0-9_ ]+$",
+        description="Title can contain only letters, digits, spaces, and underscores, 3-80 symbols"
+    ),
+    description: str = Query(
+        ...,
+        min_length=3,
+        max_length=10000,
+        description="Description must contain 3-10000 symbols"
+    ),
     user_email: str = Depends(get_current_user),
 ):
     """
     Create the assignment with provided title and description in the course with provided course_id.
+
+    Title can contain only letters, digits, spaces, and underscores.
+
+    Title must contains from 3 to 80 symbols.
+
+    Description must contains from 3 to 10000 symbols.
 
     Teacher OR Primary Instructor role required.
 

--- a/backend/routers/courses.py
+++ b/backend/routers/courses.py
@@ -1,5 +1,5 @@
 from typing import List, Optional
-from fastapi import APIRouter, Depends
+from fastapi import APIRouter, Query, Depends
 from auth import get_current_user, get_db
 import json_classes
 import logic.courses
@@ -29,9 +29,29 @@ async def get_all_courses(user_email: str = Depends(get_current_user)):
 
 
 @router.post("/create_course", response_model=json_classes.CourseId, tags=["Courses"])
-async def create_course(title: str, organization: Optional[str] = None, user_email: str = Depends(get_current_user)):
+async def create_course(
+    title: str = Query(
+        ...,
+        min_length=3,
+        max_length=80,
+        pattern=r"^[\p{L}0-9_ ]+$",
+        description="Title can contain only letters, digits, spaces, and underscores, 3-80 symbols"
+    ),
+    organization: Optional[str] = Query(
+        ...,
+        min_length=3,
+        max_length=80,
+        pattern=r"^[\p{L}0-9_ ]+$",
+        description="Organization can contain only letters, digits, spaces, and underscores, 3-80 symbols"
+    ),
+    user_email: str = Depends(get_current_user),
+):
     """
     Create the course with provided title and become a Primary Instructor in it.
+
+    Title and Organization can contain only letters, digits, spaces, and underscores.
+
+    Title and Organization must contains from 3 to 80 symbols.
 
     Organization parameter is optional / can be None.
     """

--- a/backend/routers/courses.py
+++ b/backend/routers/courses.py
@@ -38,7 +38,7 @@ async def create_course(
         description="Title can contain only letters, digits, spaces, and underscores, 3-80 symbols"
     ),
     organization: Optional[str] = Query(
-        ...,
+        None,
         min_length=3,
         max_length=80,
         pattern=r"^[\p{L}0-9_ ]+$",

--- a/backend/routers/materials.py
+++ b/backend/routers/materials.py
@@ -1,5 +1,5 @@
 from typing import List
-from fastapi import APIRouter, Depends, UploadFile, File
+from fastapi import APIRouter, Depends, Query, UploadFile, File
 from auth import get_current_user, get_db, get_storage_db
 import json_classes
 import logic.materials
@@ -11,12 +11,29 @@ router = APIRouter()
 @router.post("/create_material", response_model=json_classes.MaterialID, tags=["Materials"])
 async def create_material(
     course_id: str,
-    title: str,
-    description: str,
+    title: str = Query(
+        ...,
+        min_length=3,
+        max_length=80,
+        pattern=r"^[\p{L}0-9_ ]+$",
+        description="Title can contain only letters, digits, spaces, and underscores, 3-80 symbols"
+    ),
+    description: str = Query(
+        ...,
+        min_length=3,
+        max_length=10000,
+        description="Description must contain 3-10000 symbols"
+    ),
     user_email: str = Depends(get_current_user),
 ):
     """
     Create the material with provided title and description in the course with provided course_id.
+
+    Title can contain only letters, digits, spaces, and underscores.
+
+    Title must contains from 3 to 80 symbols.
+
+    Description must contains from 3 to 10000 symbols.
 
     Teacher OR Primary Instructor role required.
 

--- a/backend/routers/submissions.py
+++ b/backend/routers/submissions.py
@@ -1,5 +1,5 @@
 from typing import List
-from fastapi import APIRouter, Depends, UploadFile, File
+from fastapi import APIRouter, Depends, Query, UploadFile, File
 from auth import get_current_user, get_db, get_storage_db
 import json_classes
 import logic.submissions
@@ -12,11 +12,18 @@ router = APIRouter()
 async def submit_assignment(
     course_id: str,
     assignment_id: str,
-    comment: str,
+    comment: str = Query(
+        ...,
+        min_length=3,
+        max_length=10000,
+        description="Comment must contain 3-10000 symbols"
+    ),
     student_email: str = Depends(get_current_user),
 ):
     """
     Allows student to submit their assignment.
+
+    Comment must contains from 3 to 10000 symbols.
 
     Student role required.
 

--- a/backend/routers/users.py
+++ b/backend/routers/users.py
@@ -33,6 +33,10 @@ async def create_user(user: json_classes.UserCreate):
 
     User email should be in the correct format.
 
+    User name can contain only letters, digits, spaces, and underscores; user name can not start with digit.
+
+    User name must contains from 1 to 80 symbols.
+
     User password should have at least 8 symbols and contain digits, letters, and special symbols.
 
     Returns email and JWT access token for 30 minutes.

--- a/backend/tests/authorization.sh
+++ b/backend/tests/authorization.sh
@@ -14,6 +14,27 @@ fail_test "Registration with incorrect email" \
 
 # --------------------------------------------------------------------
 
+fail_test "Registration with too long name" \
+    -X POST $API_URL/create_user \
+    -H "Content-Type: application/json" \
+    -d "{\"email\":\"alice@example.com\",\"password\":\"alicePass123!\",\"name\":\"AliceAliceAliceAliceAliceAliceAliceAliceAliceAliceAliceAliceAliceAliceAliceAliceAliceAliceAliceAlice\"}"
+
+# --------------------------------------------------------------------
+
+fail_test "Registration with invalid name (dollar sign)" \
+    -X POST $API_URL/create_user \
+    -H "Content-Type: application/json" \
+    -d "{\"email\":\"alice@example.com\",\"password\":\"alicePass123!\",\"name\":\"Alice%24Alice\"}"
+
+# --------------------------------------------------------------------
+
+fail_test "Registration with invalid name (starts with digits)" \
+    -X POST $API_URL/create_user \
+    -H "Content-Type: application/json" \
+    -d "{\"email\":\"alice@example.com\",\"password\":\"alicePass123!\",\"name\":\"2025Alice\"}"
+
+# --------------------------------------------------------------------
+
 fail_test "Registration with weak password" \
     -X POST $API_URL/create_user \
     -H "Content-Type: application/json" \

--- a/backend/tests/courses.sh
+++ b/backend/tests/courses.sh
@@ -52,6 +52,10 @@ fail_test "Request to create the course with invalid organization" \
     -X POST "$API_URL/create_course?title=Math&organization=Innopolis%24University" \
     -H "Authorization: Bearer $TOKEN" \
 
+success_test "Request to create the course with no organization" \
+    -X POST "$API_URL/create_course?title=Title" \
+    -H "Authorization: Bearer $TOKEN" \
+
 # --------------------------------------------------------------------
 
 mathcourseid=$(curl -s -X POST \

--- a/backend/tests/courses.sh
+++ b/backend/tests/courses.sh
@@ -28,6 +28,32 @@ login_and_get_token "Login as Alice" \
 
 # --------------------------------------------------------------------
 
+fail_test "Request to create the course with too short name" \
+    -X POST "$API_URL/create_course?title=M&organization=Innopolis%20University" \
+    -H "Authorization: Bearer $TOKEN" \
+
+fail_test "Request to create the course with too long name" \
+    -X POST "$API_URL/create_course?title=MathMathMathMathMathMathMathMathMathMathMathMathMathMathMathMathMathMathMathMathMathMathMathMathMath&organization=Innopolis%20University" \
+    -H "Authorization: Bearer $TOKEN" \
+
+fail_test "Request to create the course with invalid name" \
+    -X POST "$API_URL/create_course?title=M%24ath&organization=Innopolis%20University" \
+    -H "Authorization: Bearer $TOKEN" \
+
+fail_test "Request to create the course with too short organization" \
+    -X POST "$API_URL/create_course?title=Math&organization=In" \
+    -H "Authorization: Bearer $TOKEN" \
+
+fail_test "Request to create the course with too long organization" \
+    -X POST "$API_URL/create_course?title=Math&organization=Innopolis%20UniversityInnopolis%20UniversityInnopolis%20UniversityInnopolis%20UniversityInnopolis%20University" \
+    -H "Authorization: Bearer $TOKEN" \
+
+fail_test "Request to create the course with invalid organization" \
+    -X POST "$API_URL/create_course?title=Math&organization=Innopolis%24University" \
+    -H "Authorization: Bearer $TOKEN" \
+
+# --------------------------------------------------------------------
+
 mathcourseid=$(curl -s -X POST \
     -H "Authorization: Bearer $TOKEN" \
     "$API_URL/create_course?title=Math&organization=Innopolis%20University" | extract_field course_id)
@@ -55,6 +81,42 @@ expected='
 '
 
 json_partial_match_test "Request the course info from Alice" "$info" "$expected" "course_id" "creation_time"
+
+# --------------------------------------------------------------------
+
+fail_test "Request to create the material with too short title" \
+    -X POST "$API_URL/create_material?course_id=$mathcourseid&title=Ti&description=Lecture%20material%20description" \
+    -H "Authorization: Bearer $TOKEN" \
+
+fail_test "Request to create the material with too long title" \
+    -X POST "$API_URL/create_material?course_id=$mathcourseid&title=TitleTitleTitleTitleTitleTitleTitleTitleTitleTitleTitleTitleTitleTitleTitleTitleTitleTitleTitleTitle&description=Lecture%20material%20description" \
+    -H "Authorization: Bearer $TOKEN" \
+
+fail_test "Request to create the material with invalid title" \
+    -X POST "$API_URL/create_material?course_id=$mathcourseid&title=Ti%24tle&description=Lecture%20material%20description" \
+    -H "Authorization: Bearer $TOKEN" \
+
+fail_test "Request to create the material with too short desctiption" \
+    -X POST "$API_URL/create_material?course_id=$mathcourseid&title=Title&description=Lecture%20material%20description" \
+    -H "Authorization: Bearer $TOKEN" \
+
+# --------------------------------------------------------------------
+
+fail_test "Request to create the assignment with too short title" \
+    -X POST "$API_URL/create_assignment?course_id=$mathcourseid&title=Ti&description=Lecture%20material%20description" \
+    -H "Authorization: Bearer $TOKEN" \
+
+fail_test "Request to create the assignment with too long title" \
+    -X POST "$API_URL/create_assignment?course_id=$mathcourseid&title=TitleTitleTitleTitleTitleTitleTitleTitleTitleTitleTitleTitleTitleTitleTitleTitleTitleTitleTitleTitle&description=Lecture%20material%20description" \
+    -H "Authorization: Bearer $TOKEN" \
+
+fail_test "Request to create the assignment with invalid title" \
+    -X POST "$API_URL/create_assignment?course_id=$mathcourseid&title=Ti%24tle&description=Lecture%20material%20description" \
+    -H "Authorization: Bearer $TOKEN" \
+
+fail_test "Request to create the assignment with too short desctiption" \
+    -X POST "$API_URL/create_assignment?course_id=$mathcourseid&title=Title&description=Lecture%20material%20description" \
+    -H "Authorization: Bearer $TOKEN" \
 
 # --------------------------------------------------------------------
 

--- a/backend/tests/courses.sh
+++ b/backend/tests/courses.sh
@@ -52,8 +52,18 @@ fail_test "Request to create the course with invalid organization" \
     -X POST "$API_URL/create_course?title=Math&organization=Innopolis%24University" \
     -H "Authorization: Bearer $TOKEN" \
 
-success_test "Request to create the course with no organization" \
+success_test "Create the course with no organization" \
     -X POST "$API_URL/create_course?title=Title" \
+    -H "Authorization: Bearer $TOKEN" \
+
+noorgcourseid=$(curl -s -X POST \
+    -H "Authorization: Bearer $TOKEN" \
+    "$API_URL/create_course?title=Math" | extract_field course_id)
+
+echo "✓ Successful Create the course with no organization"
+
+success_test "Remove the course with no organization" \
+    -X POST "$API_URL/remove_course?course_id=$noorgcourseid" \
     -H "Authorization: Bearer $TOKEN" \
 
 # --------------------------------------------------------------------

--- a/backend/tests/courses.sh
+++ b/backend/tests/courses.sh
@@ -97,25 +97,25 @@ fail_test "Request to create the material with invalid title" \
     -H "Authorization: Bearer $TOKEN" \
 
 fail_test "Request to create the material with too short desctiption" \
-    -X POST "$API_URL/create_material?course_id=$mathcourseid&title=Title&description=Lecture%20material%20description" \
+    -X POST "$API_URL/create_material?course_id=$mathcourseid&title=Title&description=De" \
     -H "Authorization: Bearer $TOKEN" \
 
 # --------------------------------------------------------------------
 
 fail_test "Request to create the assignment with too short title" \
-    -X POST "$API_URL/create_assignment?course_id=$mathcourseid&title=Ti&description=Lecture%20material%20description" \
+    -X POST "$API_URL/create_assignment?course_id=$mathcourseid&title=Ti&description=Lecture%20assignment%20description" \
     -H "Authorization: Bearer $TOKEN" \
 
 fail_test "Request to create the assignment with too long title" \
-    -X POST "$API_URL/create_assignment?course_id=$mathcourseid&title=TitleTitleTitleTitleTitleTitleTitleTitleTitleTitleTitleTitleTitleTitleTitleTitleTitleTitleTitleTitle&description=Lecture%20material%20description" \
+    -X POST "$API_URL/create_assignment?course_id=$mathcourseid&title=TitleTitleTitleTitleTitleTitleTitleTitleTitleTitleTitleTitleTitleTitleTitleTitleTitleTitleTitleTitle&description=Lecture%20assignment%20description" \
     -H "Authorization: Bearer $TOKEN" \
 
 fail_test "Request to create the assignment with invalid title" \
-    -X POST "$API_URL/create_assignment?course_id=$mathcourseid&title=Ti%24tle&description=Lecture%20material%20description" \
+    -X POST "$API_URL/create_assignment?course_id=$mathcourseid&title=Ti%24tle&description=Lecture%20assignment%20description" \
     -H "Authorization: Bearer $TOKEN" \
 
 fail_test "Request to create the assignment with too short desctiption" \
-    -X POST "$API_URL/create_assignment?course_id=$mathcourseid&title=Title&description=Lecture%20material%20description" \
+    -X POST "$API_URL/create_assignment?course_id=$mathcourseid&title=Title&description=De" \
     -H "Authorization: Bearer $TOKEN" \
 
 # --------------------------------------------------------------------

--- a/backend/tests/courses.sh
+++ b/backend/tests/courses.sh
@@ -52,10 +52,6 @@ fail_test "Request to create the course with invalid organization" \
     -X POST "$API_URL/create_course?title=Math&organization=Innopolis%24University" \
     -H "Authorization: Bearer $TOKEN" \
 
-success_test "Create the course with no organization" \
-    -X POST "$API_URL/create_course?title=Title" \
-    -H "Authorization: Bearer $TOKEN" \
-
 noorgcourseid=$(curl -s -X POST \
     -H "Authorization: Bearer $TOKEN" \
     "$API_URL/create_course?title=Math" | extract_field course_id)

--- a/backend/tests/submissions.sh
+++ b/backend/tests/submissions.sh
@@ -88,6 +88,12 @@ json_partial_match_test "Request the assignment info from Bob" "$info" "$expecte
 
 # --------------------------------------------------------------------
 
+fail_test "Request to submit the assignment with too short comment" \
+    -X POST "$API_URL/submit_assignment?course_id=$mathcourseid&assignment_id=$assignmentid&comment=An" \
+    -H "Authorization: Bearer $TOKEN" \
+
+# --------------------------------------------------------------------
+
 success_test "Submit assignment as Bob" \
     -X POST "$API_URL/submit_assignment?course_id=$mathcourseid&assignment_id=$assignmentid&comment=The%20answer%20is%2010" \
     -H "Authorization: Bearer $TOKEN" \


### PR DESCRIPTION
### Problem
Until now, user could send any string to the following fields:
- **name** in `create_user`
- **title** and **organization** in `create_course`
- **title** and **describtion** in `create_material`
- **title** and **describtion** in `create_assignment`
- **comment** in `submit_assignment`
User could send an empty string, too short string, too long string, or a string with some wierd characters
### Updates
The following constraints were developed:
- **name** in `create_user` can contain only letters, digits, spaces, and underscores, and must contain 1–80 symbols; user name can not start with digit
- **title** in `create_course` can contain only letters, digits, spaces, and underscores, and must contain 3–80 symbols
- **organization** in `create_course` can contain only letters, digits, spaces, and underscores, and must contain 3–80 symbols
- **title** in `create_material` can contain only letters, digits, spaces, and underscores, and must contain 3–80 symbols
- **describtion** in `create_material` must contain 3–10,000 symbols
- **title** in `create_assignment` can contain only letters, digits, spaces, and underscores, and must contain 3–80 symbols
- **describtion** in `create_assignment` must contain 3–10,000 symbols
- **comment** in `submit_assignment` must contain 3–10,000 symbols

Invalid tests for parameters validation also have been added.