### PR TITLE
Optional grade comment added

### DIFF
--- a/backend/json_classes.py
+++ b/backend/json_classes.py
@@ -86,6 +86,7 @@ class Submission(BaseModel):
     last_modification_time: str
     submission_text: str
     grade: Optional[int]
+    comment: Optional[str]
     gradedby_email: Optional[str]
 
 

--- a/backend/json_classes.py
+++ b/backend/json_classes.py
@@ -84,7 +84,7 @@ class Submission(BaseModel):
     student_name: str
     submission_time: str
     last_modification_time: str
-    comment: str
+    submission_text: str
     grade: Optional[int]
     gradedby_email: Optional[str]
 

--- a/backend/logic/assignments.py
+++ b/backend/logic/assignments.py
@@ -66,6 +66,8 @@ async def create_assignment_attachment(db_conn, db_cursor, storage_db_conn, stor
     # checking constraints
     constraints.assert_teacher_access(db_cursor, user_email, course_id)
     constraints.assert_assignment_exists(db_cursor, course_id, assignment_id)
+    if (len(file.filename) > 80):
+        raise HTTPException(status_code=400, detail="File name too long")
 
     # read the file
     contents = await careful_upload(file)

--- a/backend/logic/materials.py
+++ b/backend/logic/materials.py
@@ -57,6 +57,8 @@ async def create_material_attachment(db_conn, db_cursor, storage_db_conn, storag
     # checking constraints
     constraints.assert_teacher_access(db_cursor, user_email, course_id)
     constraints.assert_material_exists(db_cursor, course_id, material_id)
+    if (len(file.filename) > 80):
+        raise HTTPException(status_code=400, detail="File name too long")
 
     # read the file
     contents = await careful_upload(file)

--- a/backend/logic/submissions.py
+++ b/backend/logic/submissions.py
@@ -1,3 +1,4 @@
+from typing import Optional
 from fastapi import HTTPException, UploadFile, Response
 from constants import TIME_FORMAT
 import constraints
@@ -57,7 +58,8 @@ def get_assignment_submissions(db_cursor, course_id: str, assignment_id: str, us
             "last_modification_time": sub[3].strftime(TIME_FORMAT),
             "submission_text": sub[4],
             "grade": sub[5],
-            "gradedby_email": sub[6],
+            "comment": sub[6],
+            "gradedby_email": sub[7]
         }
         for sub in submissions
     ]
@@ -96,7 +98,8 @@ def get_submission(
         "last_modification_time": submission[3].strftime(TIME_FORMAT),
         "submission_text": submission[4],
         "grade": submission[5],
-        "gradedby_email": submission[6],
+        "comment": submission[6],
+        "gradedby_email": submission[7]
     }
     return res
 
@@ -108,13 +111,14 @@ def grade_submission(
     assignment_id: str,
     student_email: str,
     grade: str,
+    comment: Optional[str],
     user_email: str,
 ):
     # checking constraints
     constraints.assert_teacher_access(db_cursor, user_email, course_id)
     constraints.assert_submission_exists(db_cursor, course_id, assignment_id, student_email)
 
-    repo_submit.sql_update_submission_grade(db_cursor, grade, user_email, course_id, assignment_id, student_email)
+    repo_submit.sql_update_submission_grade(db_cursor, grade, comment, user_email, course_id, assignment_id, student_email)
     db_conn.commit()
 
     logger.log(db_conn, logger.TAG_ASSIGNMENT_GRADE, f"Teacher {user_email} graded an assignment {assignment_id} in {course_id} by {student_email}")

--- a/backend/logic/submissions.py
+++ b/backend/logic/submissions.py
@@ -12,7 +12,7 @@ def submit_assignment(
     db_cursor,
     course_id: str,
     assignment_id: str,
-    comment: str,
+    submission_text: str,
     student_email: str,
 ):
     # checking constraints
@@ -23,12 +23,12 @@ def submit_assignment(
 
     # inserting submission
     if submission is None:
-        repo_submit.sql_insert_submission(db_cursor, course_id, assignment_id, student_email, comment)
+        repo_submit.sql_insert_submission(db_cursor, course_id, assignment_id, student_email, submission_text)
         db_conn.commit()
 
     # updating submission if not graded
     elif submission[0] is None:
-        repo_submit.sql_update_submission_comment(db_cursor, comment, course_id, assignment_id, student_email)
+        repo_submit.sql_update_submission_text(db_cursor, submission_text, course_id, assignment_id, student_email)
         db_conn.commit()
 
     else:
@@ -55,7 +55,7 @@ def get_assignment_submissions(db_cursor, course_id: str, assignment_id: str, us
             "student_name": sub[1],
             "submission_time": sub[2].strftime(TIME_FORMAT),
             "last_modification_time": sub[3].strftime(TIME_FORMAT),
-            "comment": sub[4],
+            "submission_text": sub[4],
             "grade": sub[5],
             "gradedby_email": sub[6],
         }
@@ -94,7 +94,7 @@ def get_submission(
         "student_name": submission[1],
         "submission_time": submission[2].strftime(TIME_FORMAT),
         "last_modification_time": submission[3].strftime(TIME_FORMAT),
-        "comment": submission[4],
+        "submission_text": submission[4],
         "grade": submission[5],
         "gradedby_email": submission[6],
     }

--- a/backend/logic/submissions.py
+++ b/backend/logic/submissions.py
@@ -132,6 +132,8 @@ async def create_submission_attachment(db_conn, db_cursor, storage_db_conn, stor
         raise HTTPException(status_code=403, detail="User does not have access to this submission")
 
     constraints.assert_submission_exists(db_cursor, course_id, assignment_id, student_email)
+    if (len(file.filename) > 80):
+        raise HTTPException(status_code=400, detail="File name too long")
 
     # read the file
     contents = await careful_upload(file)

--- a/backend/repo/submissions.py
+++ b/backend/repo/submissions.py
@@ -12,7 +12,7 @@ def sql_select_submission_grade(db_cursor, course_id: str, assignment_id: str, s
 
 def sql_insert_submission(db_cursor, course_id: str, assignment_id: str, student_email: str, submission_text: str) -> None:
     db_cursor.execute(
-        "INSERT INTO course_assignments_submissions (courseid, assid, email, timeadded, timemodified, submissiontext, grade, gradedby) VALUES (%s, %s, %s, now(), now(), %s, null, null)",
+        "INSERT INTO course_assignments_submissions (courseid, assid, email, timeadded, timemodified, submissiontext, grade, comment, gradedby) VALUES (%s, %s, %s, now(), now(), %s, null, null, null)",
         (course_id, assignment_id, student_email, submission_text),
     )
 
@@ -64,7 +64,7 @@ def sql_update_submission_text(db_cursor, submission_text: str, course_id: str, 
     )
 
 
-def sql_select_submissions(db_cursor, course_id: str, assignment_id: str) -> List[Tuple[str, str, datetime, datetime, str, Optional[int], Optional[str]]]:
+def sql_select_submissions(db_cursor, course_id: str, assignment_id: str) -> List[Tuple[str, str, datetime, datetime, str, Optional[int], Optional[str], Optional[str]]]:
     db_cursor.execute(
         """
         SELECT
@@ -74,6 +74,7 @@ def sql_select_submissions(db_cursor, course_id: str, assignment_id: str) -> Lis
             s.timemodified,
             s.submissiontext,
             s.grade,
+            s.comment,
             s.gradedby
         FROM course_assignments_submissions s
         JOIN users u ON s.email = u.email
@@ -85,7 +86,7 @@ def sql_select_submissions(db_cursor, course_id: str, assignment_id: str) -> Lis
     return db_cursor.fetchall()
 
 
-def sql_select_single_submission(db_cursor, course_id: str, assignment_id: str, student_email: str) -> Tuple[str, str, datetime, datetime, str, Optional[int], Optional[str]]:
+def sql_select_single_submission(db_cursor, course_id: str, assignment_id: str, student_email: str) -> Tuple[str, str, datetime, datetime, str, Optional[int], Optional[str], Optional[str]]:
     db_cursor.execute(
         """
         SELECT
@@ -95,6 +96,7 @@ def sql_select_single_submission(db_cursor, course_id: str, assignment_id: str, 
             s.timemodified,
             s.submissiontext,
             s.grade,
+            s.comment,
             s.gradedby
         FROM course_assignments_submissions s
         JOIN users u ON s.email = u.email
@@ -105,12 +107,12 @@ def sql_select_single_submission(db_cursor, course_id: str, assignment_id: str, 
     return db_cursor.fetchone()
 
 
-def sql_update_submission_grade(db_cursor, grade: str | int, user_email: str, course_id: str, assignment_id: str, student_email: str) -> None:
+def sql_update_submission_grade(db_cursor, grade: str | int, comment: str, user_email: str, course_id: str, assignment_id: str, student_email: str) -> None:
     db_cursor.execute(
         """
         UPDATE course_assignments_submissions
-        SET grade = %s, gradedby = %s
+        SET grade = %s, comment = %s, gradedby = %s
         WHERE courseid = %s AND assid = %s AND email = %s
         """,
-        (grade, user_email, course_id, assignment_id, student_email),
+        (grade, comment, user_email, course_id, assignment_id, student_email),
     )

--- a/backend/repo/submissions.py
+++ b/backend/repo/submissions.py
@@ -10,10 +10,10 @@ def sql_select_submission_grade(db_cursor, course_id: str, assignment_id: str, s
     return db_cursor.fetchone()
 
 
-def sql_insert_submission(db_cursor, course_id: str, assignment_id: str, student_email: str, comment: str) -> None:
+def sql_insert_submission(db_cursor, course_id: str, assignment_id: str, student_email: str, submission_text: str) -> None:
     db_cursor.execute(
-        "INSERT INTO course_assignments_submissions (courseid, assid, email, timeadded, timemodified, comment, grade, gradedby) VALUES (%s, %s, %s, now(), now(), %s, null, null)",
-        (course_id, assignment_id, student_email, comment),
+        "INSERT INTO course_assignments_submissions (courseid, assid, email, timeadded, timemodified, submission_text, grade, gradedby) VALUES (%s, %s, %s, now(), now(), %s, null, null)",
+        (course_id, assignment_id, student_email, submission_text),
     )
 
 
@@ -53,14 +53,14 @@ def sql_select_submission_attachments(db_cursor, course_id: str, assignment_id: 
     return db_cursor.fetchall()
 
 
-def sql_update_submission_comment(db_cursor, comment: str, course_id: str, assignment_id: str, student_email: str) -> None:
+def sql_update_submission_text(db_cursor, submission_text: str, course_id: str, assignment_id: str, student_email: str) -> None:
     db_cursor.execute(
         """
         UPDATE course_assignments_submissions
-        SET comment = %s, timemodified = now()
+        SET submission_text = %s, timemodified = now()
         WHERE courseid = %s AND assid = %s AND email = %s
         """,
-        (comment, course_id, assignment_id, student_email),
+        (submission_text, course_id, assignment_id, student_email),
     )
 
 
@@ -72,7 +72,7 @@ def sql_select_submissions(db_cursor, course_id: str, assignment_id: str) -> Lis
             u.publicname,
             s.timeadded,
             s.timemodified,
-            s.comment,
+            s.submission_text,
             s.grade,
             s.gradedby
         FROM course_assignments_submissions s
@@ -93,7 +93,7 @@ def sql_select_single_submission(db_cursor, course_id: str, assignment_id: str, 
             u.publicname,
             s.timeadded,
             s.timemodified,
-            s.comment,
+            s.submission_text,
             s.grade,
             s.gradedby
         FROM course_assignments_submissions s

--- a/backend/repo/submissions.py
+++ b/backend/repo/submissions.py
@@ -12,7 +12,7 @@ def sql_select_submission_grade(db_cursor, course_id: str, assignment_id: str, s
 
 def sql_insert_submission(db_cursor, course_id: str, assignment_id: str, student_email: str, submission_text: str) -> None:
     db_cursor.execute(
-        "INSERT INTO course_assignments_submissions (courseid, assid, email, timeadded, timemodified, submission_text, grade, gradedby) VALUES (%s, %s, %s, now(), now(), %s, null, null)",
+        "INSERT INTO course_assignments_submissions (courseid, assid, email, timeadded, timemodified, submissiontext, grade, gradedby) VALUES (%s, %s, %s, now(), now(), %s, null, null)",
         (course_id, assignment_id, student_email, submission_text),
     )
 
@@ -57,7 +57,7 @@ def sql_update_submission_text(db_cursor, submission_text: str, course_id: str, 
     db_cursor.execute(
         """
         UPDATE course_assignments_submissions
-        SET submission_text = %s, timemodified = now()
+        SET submissiontext = %s, timemodified = now()
         WHERE courseid = %s AND assid = %s AND email = %s
         """,
         (submission_text, course_id, assignment_id, student_email),
@@ -72,7 +72,7 @@ def sql_select_submissions(db_cursor, course_id: str, assignment_id: str) -> Lis
             u.publicname,
             s.timeadded,
             s.timemodified,
-            s.submission_text,
+            s.submissiontext,
             s.grade,
             s.gradedby
         FROM course_assignments_submissions s
@@ -93,7 +93,7 @@ def sql_select_single_submission(db_cursor, course_id: str, assignment_id: str, 
             u.publicname,
             s.timeadded,
             s.timemodified,
-            s.submission_text,
+            s.submissiontext,
             s.grade,
             s.gradedby
         FROM course_assignments_submissions s

--- a/backend/repo/submissions.py
+++ b/backend/repo/submissions.py
@@ -107,7 +107,7 @@ def sql_select_single_submission(db_cursor, course_id: str, assignment_id: str, 
     return db_cursor.fetchone()
 
 
-def sql_update_submission_grade(db_cursor, grade: str | int, comment: str, user_email: str, course_id: str, assignment_id: str, student_email: str) -> None:
+def sql_update_submission_grade(db_cursor, grade: str | int, comment: Optional[str], user_email: str, course_id: str, assignment_id: str, student_email: str) -> None:
     db_cursor.execute(
         """
         UPDATE course_assignments_submissions

--- a/backend/routers/assignments.py
+++ b/backend/routers/assignments.py
@@ -87,6 +87,8 @@ async def create_assignment_attachment(
     """
     Attach the provided file to provided course assignment.
 
+    Filename should contain no more than 80 symbols.
+
     Teacher OR Primary Instructor role required.
 
     Returns the (course_id, assignment_id, file_id, filename, upload_time) for the new attachment in case of success.

--- a/backend/routers/materials.py
+++ b/backend/routers/materials.py
@@ -81,6 +81,8 @@ async def create_material_attachment(
     """
     Attach the provided file to provided course material.
 
+    Filename should contain no more than 80 symbols.
+
     Teacher OR Primary Instructor role required.
 
     Returns the (course_id, material_id, file_id, filename, upload_time) for the new attachment in case of success.

--- a/backend/routers/submissions.py
+++ b/backend/routers/submissions.py
@@ -129,6 +129,8 @@ async def create_submission_attachment(
     """
     Attach the provided file to provided course assignment submission.
 
+    Filename should contain no more than 80 symbols.
+
     Student role required.
 
     Returns the (course_id, assignment_id, student_email, file_id, filename, upload_time) for the new attachment in case of success.

--- a/backend/routers/submissions.py
+++ b/backend/routers/submissions.py
@@ -1,4 +1,4 @@
-from typing import List
+from typing import List, Optional
 from fastapi import APIRouter, Depends, Query, UploadFile, File
 from auth import get_current_user, get_db, get_storage_db
 import json_classes
@@ -44,11 +44,11 @@ async def get_assignment_submissions(course_id: str, assignment_id: str, user_em
 
     Submissions are ordered by submission_time, the first submissions are new.
 
-    Returns the list of submissions (course_id, assignment_id, student_email, student_name, submission_time, last_modification_time, submission_text, grade, gradedby_email).
+    Returns the list of submissions (course_id, assignment_id, student_email, student_name, submission_time, last_modification_time, submission_text, grade, comment, gradedby_email).
 
     The format of submission_time and last_modification_time is TIME_FORMAT.
 
-    `grade` and `gradedby_email` can be `null` if the assignment was not graded yet.
+    `grade`, `comment`, and `gradedby_email` can be `null` if the assignment was not graded yet.
     """
 
     # connection to database
@@ -70,11 +70,11 @@ async def get_submission(
     - Parent can get the submission of their student
     - Stuent can get their submissions
 
-    Returns the submission (course_id, assignment_id, student_email, student_name, submission_time, last_modification_time, submission_text, grade, gradedby_email).
+    Returns the submission (course_id, assignment_id, student_email, student_name, submission_time, last_modification_time, submission_text, grade, comment, gradedby_email).
 
     The format of submission_time and last_modification_time is TIME_FORMAT.
 
-    `grade` and `gradedby_email` can be `null` if the assignment was not graded yet.
+    `grade`, `comment`, and `gradedby_email` can be `null` if the assignment was not graded yet.
     """
 
     # connection to database
@@ -88,12 +88,20 @@ async def grade_submission(
     assignment_id: str,
     student_email: str,
     grade: str,
+    comment: Optional[str] = Query(
+        None,
+        min_length=3,
+        max_length=10000,
+        description="Comment must contain 3-10000 symbols"
+    ),
     user_email: str = Depends(get_current_user),
 ):
     """
     Allows teacher to grade student's submission.
 
     Teacher OR Primary Instructor role required.
+
+    Comment must be None or contain from 3 to 10000 symbols.
     """
 
     # connection to database
@@ -105,7 +113,8 @@ async def grade_submission(
             assignment_id,
             student_email,
             grade,
-            user_email,
+            comment,
+            user_email
         )
 
 

--- a/backend/routers/submissions.py
+++ b/backend/routers/submissions.py
@@ -12,18 +12,18 @@ router = APIRouter()
 async def submit_assignment(
     course_id: str,
     assignment_id: str,
-    comment: str = Query(
+    submission_text: str = Query(
         ...,
         min_length=3,
         max_length=10000,
-        description="Comment must contain 3-10000 symbols"
+        description="Submission text must contain 3-10000 symbols"
     ),
     student_email: str = Depends(get_current_user),
 ):
     """
     Allows student to submit their assignment.
 
-    Comment must contains from 3 to 10000 symbols.
+    Submission text must contains from 3 to 10000 symbols.
 
     Student role required.
 
@@ -32,7 +32,7 @@ async def submit_assignment(
 
     # connection to database
     with get_db() as (db_conn, db_cursor):
-        return logic.submissions.submit_assignment(db_conn, db_cursor, course_id, assignment_id, comment, student_email)
+        return logic.submissions.submit_assignment(db_conn, db_cursor, course_id, assignment_id, submission_text, student_email)
 
 
 @router.get("/get_assignment_submissions", response_model=List[json_classes.Submission], tags=["Submissions"])
@@ -44,7 +44,7 @@ async def get_assignment_submissions(course_id: str, assignment_id: str, user_em
 
     Submissions are ordered by submission_time, the first submissions are new.
 
-    Returns the list of submissions (course_id, assignment_id, student_email, student_name, submission_time, last_modification_time, comment, grade, gradedby_email).
+    Returns the list of submissions (course_id, assignment_id, student_email, student_name, submission_time, last_modification_time, submission_text, grade, gradedby_email).
 
     The format of submission_time and last_modification_time is TIME_FORMAT.
 
@@ -70,7 +70,7 @@ async def get_submission(
     - Parent can get the submission of their student
     - Stuent can get their submissions
 
-    Returns the submission (course_id, assignment_id, student_email, student_name, submission_time, last_modification_time, comment, grade, gradedby_email).
+    Returns the submission (course_id, assignment_id, student_email, student_name, submission_time, last_modification_time, submission_text, grade, gradedby_email).
 
     The format of submission_time and last_modification_time is TIME_FORMAT.
 

--- a/backend/tests/attachments.sh
+++ b/backend/tests/attachments.sh
@@ -133,7 +133,7 @@ download_file_test "Download assignment attachment by Bob" "$API_URL/download_as
 # --------------------------------------------------------------------
 
 success_test "Submit assignment as Bob" \
-    -X POST "$API_URL/submit_assignment?course_id=$mathcourseid&assignment_id=$assignmentid&comment=The%20answer%20is%2010" \
+    -X POST "$API_URL/submit_assignment?course_id=$mathcourseid&assignment_id=$assignmentid&submission_text=The%20answer%20is%2010" \
     -H "Authorization: Bearer $TOKEN" \
 
 filesubmissionid=$(curl -s -X POST \

--- a/backend/tests/submissions.sh
+++ b/backend/tests/submissions.sh
@@ -88,14 +88,14 @@ json_partial_match_test "Request the assignment info from Bob" "$info" "$expecte
 
 # --------------------------------------------------------------------
 
-fail_test "Request to submit the assignment with too short comment" \
-    -X POST "$API_URL/submit_assignment?course_id=$mathcourseid&assignment_id=$assignmentid&comment=An" \
+fail_test "Request to submit the assignment with too short submission_text" \
+    -X POST "$API_URL/submit_assignment?course_id=$mathcourseid&assignment_id=$assignmentid&submission_text=An" \
     -H "Authorization: Bearer $TOKEN" \
 
 # --------------------------------------------------------------------
 
 success_test "Submit assignment as Bob" \
-    -X POST "$API_URL/submit_assignment?course_id=$mathcourseid&assignment_id=$assignmentid&comment=The%20answer%20is%2010" \
+    -X POST "$API_URL/submit_assignment?course_id=$mathcourseid&assignment_id=$assignmentid&submission_text=The%20answer%20is%2010" \
     -H "Authorization: Bearer $TOKEN" \
 
 # --------------------------------------------------------------------
@@ -105,7 +105,7 @@ info=$(curl -s -X GET \
     "$API_URL/get_submission?course_id=$mathcourseid&assignment_id=$assignmentid&student_email=bob@example.com")
 
 expected='
-    {"course_id":"'"$mathcourseid"'","assignment_id":'$assignmentid',"student_email":"bob@example.com","student_name":"Bob","comment":"The answer is 10","grade":null,"gradedby_email":null}
+    {"course_id":"'"$mathcourseid"'","assignment_id":'$assignmentid',"student_email":"bob@example.com","student_name":"Bob","submission_text":"The answer is 10","grade":null,"gradedby_email":null}
 '
 
 json_partial_match_test "Request the submission details from Bob" "$info" "$expected" "assignment_id" "submission_time last_modification_time"
@@ -124,7 +124,7 @@ info=$(curl -s -X GET \
     "$API_URL/get_assignment_submissions?course_id=$mathcourseid&assignment_id=$assignmentid")
 
 expected='[
-    {"course_id":"'"$mathcourseid"'","assignment_id":'$assignmentid',"student_email":"bob@example.com","student_name":"Bob","comment":"The answer is 10","grade":null,"gradedby_email":null}
+    {"course_id":"'"$mathcourseid"'","assignment_id":'$assignmentid',"student_email":"bob@example.com","student_name":"Bob","submission_text":"The answer is 10","grade":null,"gradedby_email":null}
 ]'
 
 json_partial_match_test "Request the list of assignment submissions by Alice" "$info" "$expected" "assignment_id" "submission_time last_modification_time"
@@ -136,7 +136,7 @@ info=$(curl -s -X GET \
     "$API_URL/get_submission?course_id=$mathcourseid&assignment_id=$assignmentid&student_email=bob@example.com")
 
 expected='
-    {"course_id":"'"$mathcourseid"'","assignment_id":'$assignmentid',"student_email":"bob@example.com","student_name":"Bob","comment":"The answer is 10","grade":null,"gradedby_email":null}
+    {"course_id":"'"$mathcourseid"'","assignment_id":'$assignmentid',"student_email":"bob@example.com","student_name":"Bob","submission_text":"The answer is 10","grade":null,"gradedby_email":null}
 '
 
 json_partial_match_test "Request the submission details by Alice" "$info" "$expected" "assignment_id" "submission_time last_modification_time"
@@ -154,7 +154,7 @@ info=$(curl -s -X GET \
     "$API_URL/get_submission?course_id=$mathcourseid&assignment_id=$assignmentid&student_email=bob@example.com")
 
 expected='
-    {"course_id":"'"$mathcourseid"'","assignment_id":'$assignmentid',"student_email":"bob@example.com","student_name":"Bob","comment":"The answer is 10","grade":5,"gradedby_email":"alice@example.com"}
+    {"course_id":"'"$mathcourseid"'","assignment_id":'$assignmentid',"student_email":"bob@example.com","student_name":"Bob","submission_text":"The answer is 10","grade":5,"gradedby_email":"alice@example.com"}
 '
 
 json_partial_match_test "Request the submission details by Alice" "$info" "$expected" "assignment_id" "submission_time last_modification_time"
@@ -173,7 +173,7 @@ info=$(curl -s -X GET \
     "$API_URL/get_submission?course_id=$mathcourseid&assignment_id=$assignmentid&student_email=bob@example.com")
 
 expected='
-    {"course_id":"'"$mathcourseid"'","assignment_id":'$assignmentid',"student_email":"bob@example.com","student_name":"Bob","comment":"The answer is 10","grade":5,"gradedby_email":"alice@example.com"}
+    {"course_id":"'"$mathcourseid"'","assignment_id":'$assignmentid',"student_email":"bob@example.com","student_name":"Bob","submission_text":"The answer is 10","grade":5,"gradedby_email":"alice@example.com"}
 '
 
 json_partial_match_test "Request the submission details by Charlie" "$info" "$expected" "assignment_id" "submission_time last_modification_time"

--- a/backend/tests/submissions.sh
+++ b/backend/tests/submissions.sh
@@ -105,7 +105,7 @@ info=$(curl -s -X GET \
     "$API_URL/get_submission?course_id=$mathcourseid&assignment_id=$assignmentid&student_email=bob@example.com")
 
 expected='
-    {"course_id":"'"$mathcourseid"'","assignment_id":'$assignmentid',"student_email":"bob@example.com","student_name":"Bob","submission_text":"The answer is 10","grade":null,"gradedby_email":null}
+    {"course_id":"'"$mathcourseid"'","assignment_id":'$assignmentid',"student_email":"bob@example.com","student_name":"Bob","submission_text":"The answer is 10","grade":null,"comment":null,"gradedby_email":null}
 '
 
 json_partial_match_test "Request the submission details from Bob" "$info" "$expected" "assignment_id" "submission_time last_modification_time"
@@ -124,7 +124,7 @@ info=$(curl -s -X GET \
     "$API_URL/get_assignment_submissions?course_id=$mathcourseid&assignment_id=$assignmentid")
 
 expected='[
-    {"course_id":"'"$mathcourseid"'","assignment_id":'$assignmentid',"student_email":"bob@example.com","student_name":"Bob","submission_text":"The answer is 10","grade":null,"gradedby_email":null}
+    {"course_id":"'"$mathcourseid"'","assignment_id":'$assignmentid',"student_email":"bob@example.com","student_name":"Bob","submission_text":"The answer is 10","grade":null,"comment":null,"gradedby_email":null}
 ]'
 
 json_partial_match_test "Request the list of assignment submissions by Alice" "$info" "$expected" "assignment_id" "submission_time last_modification_time"
@@ -136,7 +136,7 @@ info=$(curl -s -X GET \
     "$API_URL/get_submission?course_id=$mathcourseid&assignment_id=$assignmentid&student_email=bob@example.com")
 
 expected='
-    {"course_id":"'"$mathcourseid"'","assignment_id":'$assignmentid',"student_email":"bob@example.com","student_name":"Bob","submission_text":"The answer is 10","grade":null,"gradedby_email":null}
+    {"course_id":"'"$mathcourseid"'","assignment_id":'$assignmentid',"student_email":"bob@example.com","student_name":"Bob","submission_text":"The answer is 10","grade":null,"comment":null,"gradedby_email":null}
 '
 
 json_partial_match_test "Request the submission details by Alice" "$info" "$expected" "assignment_id" "submission_time last_modification_time"
@@ -144,7 +144,7 @@ json_partial_match_test "Request the submission details by Alice" "$info" "$expe
 # --------------------------------------------------------------------
 
 success_test "Grade submission by Alice" \
-    -X POST "$API_URL/grade_submission?course_id=$mathcourseid&assignment_id=$assignmentid&student_email=bob@example.com&grade=5" \
+    -X POST "$API_URL/grade_submission?course_id=$mathcourseid&assignment_id=$assignmentid&student_email=bob@example.com&grade=5&comment=Good%20job" \
     -H "Authorization: Bearer $TOKEN" \
 
 # --------------------------------------------------------------------
@@ -154,7 +154,7 @@ info=$(curl -s -X GET \
     "$API_URL/get_submission?course_id=$mathcourseid&assignment_id=$assignmentid&student_email=bob@example.com")
 
 expected='
-    {"course_id":"'"$mathcourseid"'","assignment_id":'$assignmentid',"student_email":"bob@example.com","student_name":"Bob","submission_text":"The answer is 10","grade":5,"gradedby_email":"alice@example.com"}
+    {"course_id":"'"$mathcourseid"'","assignment_id":'$assignmentid',"student_email":"bob@example.com","student_name":"Bob","submission_text":"The answer is 10","grade":5,"comment":"Good job","gradedby_email":"alice@example.com"}
 '
 
 json_partial_match_test "Request the submission details by Alice" "$info" "$expected" "assignment_id" "submission_time last_modification_time"
@@ -173,7 +173,7 @@ info=$(curl -s -X GET \
     "$API_URL/get_submission?course_id=$mathcourseid&assignment_id=$assignmentid&student_email=bob@example.com")
 
 expected='
-    {"course_id":"'"$mathcourseid"'","assignment_id":'$assignmentid',"student_email":"bob@example.com","student_name":"Bob","submission_text":"The answer is 10","grade":5,"gradedby_email":"alice@example.com"}
+    {"course_id":"'"$mathcourseid"'","assignment_id":'$assignmentid',"student_email":"bob@example.com","student_name":"Bob","submission_text":"The answer is 10","grade":5,"comment":"Good job","gradedby_email":"alice@example.com"}
 '
 
 json_partial_match_test "Request the submission details by Charlie" "$info" "$expected" "assignment_id" "submission_time last_modification_time"

--- a/database/system/initialize.sql
+++ b/database/system/initialize.sql
@@ -43,7 +43,7 @@ CREATE TABLE course_assignments_submissions(
     email text REFERENCES users ON DELETE CASCADE,
     timeadded timestamp NOT NULL,
     timemodified timestamp NOT NULL CHECK (timemodified >= timeadded),
-    comment text NOT NULL CHECK (length(comment) <= 1000),
+    submissiontext text NOT NULL CHECK (length(submissiontext) <= 1000),
     grade int NULL,
     gradedby text NULL REFERENCES users ON DELETE SET NULL,
     FOREIGN KEY (courseid, assid) REFERENCES course_assignments ON DELETE CASCADE,

--- a/database/system/initialize.sql
+++ b/database/system/initialize.sql
@@ -45,6 +45,7 @@ CREATE TABLE course_assignments_submissions(
     timemodified timestamp NOT NULL CHECK (timemodified >= timeadded),
     submissiontext text NOT NULL CHECK (length(submissiontext) <= 1000),
     grade int NULL,
+    comment text NULL,
     gradedby text NULL REFERENCES users ON DELETE SET NULL,
     FOREIGN KEY (courseid, assid) REFERENCES course_assignments ON DELETE CASCADE,
     PRIMARY KEY (courseid, assid, email)

--- a/database/system/initialize.sql
+++ b/database/system/initialize.sql
@@ -3,7 +3,7 @@ CREATE DATABASE edhub;
 
 CREATE TABLE users(
     email text PRIMARY KEY CHECK (length(email) <= 254),
-    publicname text NOT NULL CHECK (length(publicname) <= 128),
+    publicname text NOT NULL CHECK (length(publicname) <= 80),
     isadmin bool NOT NULL DEFAULT 'f',
     timeregistered timestamp NOT NULL,
     passwordhash text NOT NULL
@@ -11,8 +11,8 @@ CREATE TABLE users(
 
 CREATE TABLE courses(
     courseid uuid PRIMARY KEY,
-    name text NOT NULL CHECK (length(name) <= 128),
-    organization text NULL CHECK (length(organization) <= 128),
+    name text NOT NULL CHECK (length(name) BETWEEN 3 AND 80),
+    organization text NULL CHECK (length(organization) BETWEEN 3 AND 80),
     instructor text NOT NULL REFERENCES users(email) ON DELETE CASCADE,
     timecreated timestamp NOT NULL
 );
@@ -22,8 +22,8 @@ CREATE TABLE course_materials(
     matid serial NOT NULL,
     timeadded timestamp NOT NULL,
     author text NULL REFERENCES users(email) ON DELETE SET NULL,
-    name text NOT NULL CHECK (length(name) <= 100),
-    description text NOT NULL CHECK (length(description) <= 1000),
+    name text NOT NULL CHECK (length(name) BETWEEN 3 AND 80),
+    description text NOT NULL CHECK (length(description) BETWEEN 3 AND 10000),
     PRIMARY KEY (courseid, matid)
 );
 
@@ -32,8 +32,8 @@ CREATE TABLE course_assignments(
     assid serial NOT NULL,
     timeadded timestamp NOT NULL,
     author text NULL REFERENCES users(email) ON DELETE SET NULL,
-    name text NOT NULL CHECK (length(name) <= 100),
-    description text NOT NULL CHECK (length(description) <= 1000),
+    name text NOT NULL CHECK (length(name) BETWEEN 3 AND 80),
+    description text NOT NULL CHECK (length(description) BETWEEN 3 AND 10000),
     PRIMARY KEY (courseid, assid)
 );
 
@@ -43,9 +43,9 @@ CREATE TABLE course_assignments_submissions(
     email text REFERENCES users ON DELETE CASCADE,
     timeadded timestamp NOT NULL,
     timemodified timestamp NOT NULL CHECK (timemodified >= timeadded),
-    submissiontext text NOT NULL CHECK (length(submissiontext) <= 1000),
+    submissiontext text NOT NULL CHECK (length(submissiontext) BETWEEN 3 AND 10000),
     grade int NULL,
-    comment text NULL,
+    comment text NULL CHECK (length(comment) BETWEEN 3 AND 10000),
     gradedby text NULL REFERENCES users ON DELETE SET NULL,
     FOREIGN KEY (courseid, assid) REFERENCES course_assignments ON DELETE CASCADE,
     PRIMARY KEY (courseid, assid, email)
@@ -81,7 +81,7 @@ CREATE TABLE material_files(
     courseid uuid,
     matid int,
     fileid uuid,
-    filename text NOT NULL CHECK (length(filename) <= 256),
+    filename text NOT NULL CHECK (length(filename) <= 80),
     uploadtime timestamp NOT NULL,
     FOREIGN KEY (courseid, matid) REFERENCES course_materials ON DELETE CASCADE,
     PRIMARY KEY (courseid, matid, fileid)
@@ -91,7 +91,7 @@ CREATE TABLE assignment_files(
     courseid uuid,
     assid int,
     fileid uuid,
-    filename text NOT NULL CHECK (length(filename) <= 256),
+    filename text NOT NULL CHECK (length(filename) <= 80),
     uploadtime timestamp NOT NULL,
     FOREIGN KEY (courseid, assid) REFERENCES course_assignments ON DELETE CASCADE,
     PRIMARY KEY (courseid, assid, fileid)
@@ -102,7 +102,7 @@ CREATE TABLE submissions_files(
     assid int,
     email text,
     fileid uuid,
-    filename text NOT NULL CHECK (length(filename) <= 256),
+    filename text NOT NULL CHECK (length(filename) <= 80),
     uploadtime timestamp NOT NULL,
     FOREIGN KEY (courseid, assid, email) REFERENCES course_assignments_submissions ON DELETE CASCADE,
     PRIMARY KEY (courseid, assid, email, fileid)


### PR DESCRIPTION
### Feature
Now, when grading the assignment, a teacher can provide not only numerical grade, but also a textual comment for the student. However, the `comment` parameter is optional and can be None, i.e. teacher can just provide a single numerical grades without any justifications.
#### Implementation details
- the text that students submit (was previously called `comment`) is now called `submissiontext`
- a `comment` field is now used to store the comment from the teacher about the student's work