### PR TITLE
API endpoints for the Grades page

### DIFF
--- a/.github/workflows/backend-tests.yml
+++ b/.github/workflows/backend-tests.yml
@@ -237,6 +237,10 @@ jobs:
         run: |
           ./backend/tests/submissions.sh || exit 1
 
+      - name: Grades tests
+        run: |
+          ./backend/tests/grades.sh || exit 1
+
       - name: Attachments tests
         run: |
           ./backend/tests/attachments.sh || exit 1

--- a/backend/json_classes.py
+++ b/backend/json_classes.py
@@ -128,7 +128,7 @@ class StudentsGrades(BaseModel):
 
 class AssignmentGrade(BaseModel):
     assignment_name: str
-    assignment_id: str
+    assignment_id: int
     grade: Optional[int]
     comment: Optional[str]
     grader_name: Optional[str]

--- a/backend/json_classes.py
+++ b/backend/json_classes.py
@@ -120,12 +120,12 @@ class UserNewPassword(BaseModel):
     password: str
     new_password: str
 
-class StudentsGrades:
+class StudentsGrades(BaseModel):
     name: str
     email: str
     grades: List[Optional[int]]
 
-class AssignmentGrade:
+class AssignmentGrade(BaseModel):
     assignment_name: str
     assignment_id: str
     grade: Optional[int]

--- a/backend/json_classes.py
+++ b/backend/json_classes.py
@@ -88,6 +88,7 @@ class Submission(BaseModel):
     grade: Optional[int]
     comment: Optional[str]
     gradedby_email: Optional[str]
+    gradedby_name: Optional[str]
 
 
 class SubmissionAttachmentMetadata(BaseModel):

--- a/backend/json_classes.py
+++ b/backend/json_classes.py
@@ -1,4 +1,4 @@
-from typing import Optional
+from typing import Optional, List
 from pydantic import BaseModel
 
 class Success(BaseModel):
@@ -18,11 +18,11 @@ class CourseRole(BaseModel):
     is_admin: bool
 
 
-class CourseId(BaseModel):
+class CourseID(BaseModel):
     course_id: str
 
 
-class Course(CourseId):
+class Course(CourseID):
     title: str
     instructor: str
     organization: Optional[str]
@@ -119,3 +119,16 @@ class UserNewPassword(BaseModel):
     email: str
     password: str
     new_password: str
+
+class StudentsGrades:
+    name: str
+    email: str
+    grades: List[Optional[int]]
+
+class AssignmentGrade:
+    assignment_name: str
+    assignment_id: str
+    grade: Optional[int]
+    comment: Optional[str]
+    grader_name: Optional[str]
+    grader_email: Optional[str]

--- a/backend/logic/assignments.py
+++ b/backend/logic/assignments.py
@@ -44,7 +44,7 @@ def get_assignment(db_cursor, course_id: str, assignment_id: str, user_email: st
     # checking constraints
     constraints.assert_course_access(db_cursor, user_email, course_id)
 
-    # searching for assignments
+    # searching for the assignment
     assignment = repo_ass.sql_select_assignment(db_cursor, course_id, assignment_id)
     if not assignment:
         raise HTTPException(status_code=404, detail="Assignment not found")
@@ -57,6 +57,27 @@ def get_assignment(db_cursor, course_id: str, assignment_id: str, user_email: st
         "description": assignment[4],
         "author": assignment[5],
     }
+    return res
+
+
+def get_course_assignments(db_cursor, course_id: str, user_email: str):
+
+    # checking constraints
+    constraints.assert_course_access(db_cursor, user_email, course_id)
+
+    # searching for assignments
+    assignments = repo_ass.sql_select_course_assignments(db_cursor, course_id)
+
+    res = []
+    for ass in assignments:
+        res.append({
+            "course_id": str(ass[0]),
+            "assignment_id": ass[1],
+            "creation_time": ass[2].strftime(TIME_FORMAT),
+            "title": ass[3],
+            "description": ass[4],
+            "author": ass[5],
+        })
     return res
 
 

--- a/backend/logic/assignments.py
+++ b/backend/logic/assignments.py
@@ -68,16 +68,17 @@ def get_course_assignments(db_cursor, course_id: str, user_email: str):
     # searching for assignments
     assignments = repo_ass.sql_select_course_assignments(db_cursor, course_id)
 
-    res = []
-    for ass in assignments:
-        res.append({
+    res = [
+        {
             "course_id": str(ass[0]),
             "assignment_id": ass[1],
             "creation_time": ass[2].strftime(TIME_FORMAT),
             "title": ass[3],
             "description": ass[4],
             "author": ass[5],
-        })
+        }
+        for ass in assignments
+    ]
     return res
 
 

--- a/backend/logic/grades.py
+++ b/backend/logic/grades.py
@@ -46,9 +46,17 @@ def get_all_course_grades(db_cursor, course_id: str, user_email: str):
 
     table = []
     for student in students:
+        grades = []
+        for ass in assignments:
+            grade = repo_grades.sql_select_submission_grade(db_cursor, course_id, ass[1], student[0])
+            if grade is None:
+                grades.append(None)
+            else:
+                grades.append(grade[0])
+
         table.append({"name": student[1],
                       "email": student[0], 
-                      "grades": repo_grades.sql_select_students_grades(db_cursor, course_id, student[0])})
+                      "grades": grades})
     return table
 
 
@@ -69,10 +77,18 @@ def get_student_course_grades(db_cursor, course_id: str, student_email: str, use
     table = []
     for ass in assignments:
         sbmt = repo_submissions.sql_select_single_submission(db_cursor, course_id, ass[1], student_email)
-        table.append({"assignment_name": ass[3],
-                      "assignment_id": ass[1],
-                      "grade": sbmt[5],
-                      "comment": sbmt[6],
-                      "grader_name": sbmt[8],
-                      "grader_email": sbmt[7]})
+        if sbmt is None:
+            table.append({"assignment_name": ass[3],
+                        "assignment_id": ass[1],
+                        "grade": None,
+                        "comment": None,
+                        "grader_name": None,
+                        "grader_email": None})
+        else:
+            table.append({"assignment_name": ass[3],
+                        "assignment_id": ass[1],
+                        "grade": sbmt[5],
+                        "comment": sbmt[6],
+                        "grader_name": sbmt[8],
+                        "grader_email": sbmt[7]})
     return table

--- a/backend/logic/grades.py
+++ b/backend/logic/grades.py
@@ -71,6 +71,9 @@ def get_student_course_grades(db_cursor, course_id: str, student_email: str, use
     ):
         raise HTTPException(status_code=403, detail="User does not have access to the grades of this student")
 
+    # check if the student is enrooled in the course
+    constraints.assert_student_access(db_cursor, student_email, course_id)
+
     # check if there are any assignments within the course
     assignments = repo_assignments.sql_select_course_assignments(db_cursor, course_id)
     if len(assignments) == 0:

--- a/backend/logic/grades.py
+++ b/backend/logic/grades.py
@@ -46,7 +46,7 @@ def get_all_course_grades(db_cursor, course_id: str, user_email: str):
 
     table = []
     for student in students:
-        table.append({"name": student[1], 
+        table.append({"name": student[1],
                       "email": student[0], 
                       "grades": repo_grades.sql_select_students_grades(db_cursor, course_id, student[0])})
     return table

--- a/backend/logic/grades.py
+++ b/backend/logic/grades.py
@@ -29,6 +29,7 @@ def grade_submission(
     return {"success": True}
 
 
+# TODO: подумать над оптимизацией запросов
 def get_all_course_grades(db_cursor, course_id: str, user_email: str):
 
     # checking constraints
@@ -60,6 +61,7 @@ def get_all_course_grades(db_cursor, course_id: str, user_email: str):
     return table
 
 
+# TODO: подумать над оптимизацией запросов
 def get_student_course_grades(db_cursor, course_id: str, student_email: str, user_email: str):
     # checking constraints
     if not (

--- a/backend/logic/grades.py
+++ b/backend/logic/grades.py
@@ -1,6 +1,9 @@
 from typing import Optional
+from fastapi import HTTPException
 import constraints
-import repo.submissions as repo_submit
+import repo.grades as repo_grades
+import repo.assignments as repo_assignments
+import repo.students as repo_students
 import logic.logging as logger
 
 
@@ -18,8 +21,53 @@ def grade_submission(
     constraints.assert_teacher_access(db_cursor, user_email, course_id)
     constraints.assert_submission_exists(db_cursor, course_id, assignment_id, student_email)
 
-    repo_submit.sql_update_submission_grade(db_cursor, grade, comment, user_email, course_id, assignment_id, student_email)
+    repo_grades.sql_update_submission_grade(db_cursor, grade, comment, user_email, course_id, assignment_id, student_email)
 
     logger.log(db_conn, logger.TAG_ASSIGNMENT_GRADE, f"Teacher {user_email} graded an assignment {assignment_id} in {course_id} by {student_email}")
 
     return {"success": True}
+
+
+def get_all_course_grades(db_cursor, course_id: str, user_email: str):
+
+    # checking constraints
+    constraints.assert_teacher_access(db_cursor, user_email, course_id)
+
+    # check if there are any students enrolled in the course
+    students = repo_students.sql_select_enrolled_students(db_cursor, course_id)
+    if len(students) == 0:
+        raise HTTPException(status_code=404, detail="Empty grade table (there are no students enrolled)")
+
+    # check if there are any assignments within the course
+    assignments = repo_assignments.sql_select_course_assignments(db_cursor, course_id)
+    if len(assignments) == 0:
+        raise HTTPException(status_code=404, detail="Empty grade table (there are no assignments published)")
+
+    # TODO: return table
+    table = [
+        {"name": "Gleb Popov", "email": "g@p.ru", "grades": [5, 4, 3]},
+        {"name": "John Does", "email": "j@d.ru", "grades": [None, 4, 3]}
+    ]
+    return table
+
+
+def get_student_course_grades(db_cursor, course_id: str, student_email: str, user_email: str):
+    # checking constraints
+    if not (
+        constraints.check_teacher_access(db_cursor, user_email, course_id)
+        or constraints.check_parent_student_access(db_cursor, user_email, student_email, course_id)
+        or student_email == user_email
+    ):
+        raise HTTPException(status_code=403, detail="User does not have access to the grades of this student")
+
+    # check if there are any assignments within the course
+    assignments = repo_assignments.sql_select_course_assignments(db_cursor, course_id)
+    if len(assignments) == 0:
+        raise HTTPException(status_code=404, detail="Empty grade table (there are no assignments published)")
+
+    # TODO: return table
+    table = [
+        {"assignment_name": "Ass 1", "assignment_id": 0, "grade": 5, "comment": "Good job!", "grader_name": "Artem", "grader_email": "mail@mail.ru"},
+        {"assignment_name": "Ass 2", "assignment_id": 1, "grade": None, "comment": None, "grader_name": None, "grader_email": None},
+    ]
+    return table

--- a/backend/logic/grades.py
+++ b/backend/logic/grades.py
@@ -13,7 +13,7 @@ def grade_submission(
     course_id: str,
     assignment_id: str,
     student_email: str,
-    grade: str,
+    grade: int,
     comment: Optional[str],
     user_email: str,
 ):

--- a/backend/logic/grades.py
+++ b/backend/logic/grades.py
@@ -3,6 +3,7 @@ from fastapi import HTTPException
 import constraints
 import repo.grades as repo_grades
 import repo.assignments as repo_assignments
+import repo.submissions as repo_submissions
 import repo.students as repo_students
 import logic.logging as logger
 
@@ -43,11 +44,11 @@ def get_all_course_grades(db_cursor, course_id: str, user_email: str):
     if len(assignments) == 0:
         raise HTTPException(status_code=404, detail="Empty grade table (there are no assignments published)")
 
-    # TODO: return table
-    table = [
-        {"name": "Gleb Popov", "email": "g@p.ru", "grades": [5, 4, 3]},
-        {"name": "John Does", "email": "j@d.ru", "grades": [None, 4, 3]}
-    ]
+    table = []
+    for student in students:
+        table.append({"name": student[1], 
+                      "email": student[0], 
+                      "grades": repo_grades.sql_select_students_grades(db_cursor, course_id, student[0])})
     return table
 
 
@@ -65,9 +66,13 @@ def get_student_course_grades(db_cursor, course_id: str, student_email: str, use
     if len(assignments) == 0:
         raise HTTPException(status_code=404, detail="Empty grade table (there are no assignments published)")
 
-    # TODO: return table
-    table = [
-        {"assignment_name": "Ass 1", "assignment_id": 0, "grade": 5, "comment": "Good job!", "grader_name": "Artem", "grader_email": "mail@mail.ru"},
-        {"assignment_name": "Ass 2", "assignment_id": 1, "grade": None, "comment": None, "grader_name": None, "grader_email": None},
-    ]
+    table = []
+    for ass in assignments:
+        sbmt = repo_submissions.sql_select_single_submission(db_cursor, course_id, ass[1], student_email)
+        table.append({"assignment_name": ass[0],
+                      "assignment_id": ass[1],
+                      "grade": sbmt[5],
+                      "comment": sbmt[6],
+                      "grader_name": sbmt[8],
+                      "grader_email": sbmt[7]})
     return table

--- a/backend/logic/grades.py
+++ b/backend/logic/grades.py
@@ -69,7 +69,7 @@ def get_student_course_grades(db_cursor, course_id: str, student_email: str, use
     table = []
     for ass in assignments:
         sbmt = repo_submissions.sql_select_single_submission(db_cursor, course_id, ass[1], student_email)
-        table.append({"assignment_name": ass[0],
+        table.append({"assignment_name": ass[3],
                       "assignment_id": ass[1],
                       "grade": sbmt[5],
                       "comment": sbmt[6],

--- a/backend/logic/grades.py
+++ b/backend/logic/grades.py
@@ -80,21 +80,15 @@ def get_student_course_grades(db_cursor, course_id: str, student_email: str, use
     if len(assignments) == 0:
         raise HTTPException(status_code=404, detail="Empty grade table (there are no assignments published)")
 
-    table = []
-    for ass in assignments:
-        sbmt = repo_submissions.sql_select_single_submission(db_cursor, course_id, ass[1], student_email)
-        if sbmt is None:
-            table.append({"assignment_name": ass[3],
-                        "assignment_id": ass[1],
-                        "grade": None,
-                        "comment": None,
-                        "grader_name": None,
-                        "grader_email": None})
-        else:
-            table.append({"assignment_name": ass[3],
-                        "assignment_id": ass[1],
-                        "grade": sbmt[5],
-                        "comment": sbmt[6],
-                        "grader_name": sbmt[8],
-                        "grader_email": sbmt[7]})
+    table = [
+        {
+            "assignment_name": grade[0],
+            "assignment_id": grade[1],
+            "grade": grade[2],
+            "comment": grade[3],
+            "grader_name": grade[4],
+            "grader_email": grade[5]
+        }
+        for grade in repo_grades.sql_select_student_grades(db_cursor, course_id, student_email)
+    ]
     return table

--- a/backend/logic/grades.py
+++ b/backend/logic/grades.py
@@ -72,7 +72,8 @@ def get_student_course_grades(db_cursor, course_id: str, student_email: str, use
         raise HTTPException(status_code=403, detail="User does not have access to the grades of this student")
 
     # check if the student is enrooled in the course
-    constraints.assert_student_access(db_cursor, student_email, course_id)
+    if not constraints.check_student_access(db_cursor, student_email, course_id):
+        raise HTTPException(status_code=403, detail="User is not a student at this course")
 
     # check if there are any assignments within the course
     assignments = repo_assignments.sql_select_course_assignments(db_cursor, course_id)

--- a/backend/logic/grades.py
+++ b/backend/logic/grades.py
@@ -1,0 +1,25 @@
+from typing import Optional
+import constraints
+import repo.submissions as repo_submit
+import logic.logging as logger
+
+
+def grade_submission(
+    db_conn,
+    db_cursor,
+    course_id: str,
+    assignment_id: str,
+    student_email: str,
+    grade: str,
+    comment: Optional[str],
+    user_email: str,
+):
+    # checking constraints
+    constraints.assert_teacher_access(db_cursor, user_email, course_id)
+    constraints.assert_submission_exists(db_cursor, course_id, assignment_id, student_email)
+
+    repo_submit.sql_update_submission_grade(db_cursor, grade, comment, user_email, course_id, assignment_id, student_email)
+
+    logger.log(db_conn, logger.TAG_ASSIGNMENT_GRADE, f"Teacher {user_email} graded an assignment {assignment_id} in {course_id} by {student_email}")
+
+    return {"success": True}

--- a/backend/logic/submissions.py
+++ b/backend/logic/submissions.py
@@ -33,7 +33,7 @@ def submit_assignment(
     else:
         raise HTTPException(status_code=409, detail="Can't edit the submission after it was graded.")
 
-    logger.log(db_conn, logger.TAG_ASSIGNMENT_SUBMIT, f"Student {student_email} submitted an assignment{assignment_id} in {course_id}")
+    logger.log(db_conn, logger.TAG_ASSIGNMENT_SUBMIT, f"Student {student_email} submitted an assignment {assignment_id} in {course_id}")
 
     return {"success": True}
 

--- a/backend/logic/submissions.py
+++ b/backend/logic/submissions.py
@@ -57,7 +57,8 @@ def get_assignment_submissions(db_cursor, course_id: str, assignment_id: str, us
             "submission_text": sub[4],
             "grade": sub[5],
             "comment": sub[6],
-            "gradedby_email": sub[7]
+            "gradedby_email": sub[7],
+            "gradedby_name": sub[8]
         }
         for sub in submissions
     ]
@@ -97,7 +98,8 @@ def get_submission(
         "submission_text": submission[4],
         "grade": submission[5],
         "comment": submission[6],
-        "gradedby_email": submission[7]
+        "gradedby_email": submission[7],
+        "gradedby_name": submission[8]
     }
     return res
 

--- a/backend/logic/submissions.py
+++ b/backend/logic/submissions.py
@@ -1,4 +1,3 @@
-from typing import Optional
 from fastapi import HTTPException, UploadFile, Response
 from constants import TIME_FORMAT
 import constraints
@@ -100,27 +99,6 @@ def get_submission(
         "gradedby_email": submission[7]
     }
     return res
-
-
-def grade_submission(
-    db_conn,
-    db_cursor,
-    course_id: str,
-    assignment_id: str,
-    student_email: str,
-    grade: str,
-    comment: Optional[str],
-    user_email: str,
-):
-    # checking constraints
-    constraints.assert_teacher_access(db_cursor, user_email, course_id)
-    constraints.assert_submission_exists(db_cursor, course_id, assignment_id, student_email)
-
-    repo_submit.sql_update_submission_grade(db_cursor, grade, comment, user_email, course_id, assignment_id, student_email)
-
-    logger.log(db_conn, logger.TAG_ASSIGNMENT_GRADE, f"Teacher {user_email} graded an assignment {assignment_id} in {course_id} by {student_email}")
-
-    return {"success": True}
 
 
 async def create_submission_attachment(db_conn, db_cursor, storage_db_conn, storage_db_cursor, course_id: str, assignment_id: str, student_email: str, file: UploadFile, user_email: str):

--- a/backend/logic/submissions.py
+++ b/backend/logic/submissions.py
@@ -2,6 +2,7 @@ from fastapi import HTTPException, UploadFile, Response
 from constants import TIME_FORMAT
 import constraints
 import repo.submissions as repo_submit
+import repo.grades as repo_grades
 import repo.files as repo_files
 import logic.logging as logger
 from logic.uploading import careful_upload
@@ -19,7 +20,7 @@ def submit_assignment(
     constraints.assert_student_access(db_cursor, student_email, course_id)
     constraints.assert_assignment_exists(db_cursor, course_id, assignment_id)
 
-    submission = repo_submit.sql_select_submission_grade(db_cursor, course_id, assignment_id, student_email)
+    submission = repo_grades.sql_select_submission_grade(db_cursor, course_id, assignment_id, student_email)
 
     # inserting submission
     if submission is None:

--- a/backend/main.py
+++ b/backend/main.py
@@ -5,6 +5,7 @@ from auth import get_db
 
 import routers.assignments
 import routers.submissions
+import routers.grades
 import routers.courses
 import routers.materials
 import routers.parents
@@ -34,6 +35,7 @@ app = FastAPI(
 )
 app.include_router(routers.assignments.router)
 app.include_router(routers.submissions.router)
+app.include_router(routers.grades.router)
 app.include_router(routers.courses.router)
 app.include_router(routers.materials.router)
 app.include_router(routers.parents.router)

--- a/backend/repo/assignments.py
+++ b/backend/repo/assignments.py
@@ -65,7 +65,7 @@ def sql_select_assignment_attachments(db_cursor, course_id: str, assignment_id: 
     return db_cursor.fetchall()
 
 
-def sql_select_course_assignments(db_cursor, course_id: str) -> List[Tuple[str, int]]:
+def sql_select_course_assignments(db_cursor, course_id: str) -> List[Tuple[UUID, int, datetime, str, str, Optional[str]]]:
     db_cursor.execute(
         """
         SELECT courseid, assid, timeadded, name, description, author

--- a/backend/repo/assignments.py
+++ b/backend/repo/assignments.py
@@ -63,3 +63,11 @@ def sql_select_assignment_attachments(db_cursor, course_id: str, assignment_id: 
         (course_id, assignment_id),
     )
     return db_cursor.fetchall()
+
+
+def sql_select_course_assignments(db_cursor, course_id: str) -> List[Tuple[str, int]]:
+    db_cursor.execute(
+        "SELECT name, assid FROM course_assignments WHERE courseid = %s",
+        (course_id),
+    )
+    return db_cursor.fetchall()

--- a/backend/repo/assignments.py
+++ b/backend/repo/assignments.py
@@ -67,7 +67,11 @@ def sql_select_assignment_attachments(db_cursor, course_id: str, assignment_id: 
 
 def sql_select_course_assignments(db_cursor, course_id: str) -> List[Tuple[str, int]]:
     db_cursor.execute(
-        "SELECT name, assid FROM course_assignments WHERE courseid = %s ORDER BY assid",
+        """
+        SELECT courseid, assid, timeadded, name, description, author
+        FROM course_assignments
+        WHERE courseid = %s ORDER BY assid
+        """,
         (course_id),
     )
     return db_cursor.fetchall()

--- a/backend/repo/assignments.py
+++ b/backend/repo/assignments.py
@@ -72,6 +72,6 @@ def sql_select_course_assignments(db_cursor, course_id: str) -> List[Tuple[str, 
         FROM course_assignments
         WHERE courseid = %s ORDER BY assid
         """,
-        (course_id),
+        (course_id, ),
     )
     return db_cursor.fetchall()

--- a/backend/repo/assignments.py
+++ b/backend/repo/assignments.py
@@ -67,7 +67,7 @@ def sql_select_assignment_attachments(db_cursor, course_id: str, assignment_id: 
 
 def sql_select_course_assignments(db_cursor, course_id: str) -> List[Tuple[str, int]]:
     db_cursor.execute(
-        "SELECT name, assid FROM course_assignments WHERE courseid = %s",
+        "SELECT name, assid FROM course_assignments WHERE courseid = %s ORDER BY assid",
         (course_id),
     )
     return db_cursor.fetchall()

--- a/backend/repo/grades.py
+++ b/backend/repo/grades.py
@@ -19,7 +19,7 @@ def sql_update_submission_grade(db_cursor, grade: str | int, comment: Optional[s
         (grade, comment, user_email, course_id, assignment_id, student_email),
     )
 
-def sql_select_student_grades(db_cursor, course_id: str, student_email: str) -> List[str, int, Optional[int], Optional[str], Optional[str], Optional[str]]:
+def sql_select_student_grades(db_cursor, course_id: str, student_email: str) -> List[Tuple[str, int, Optional[int], Optional[str], Optional[str], Optional[str]]]:
     db_cursor.execute(
         """
         SELECT 

--- a/backend/repo/grades.py
+++ b/backend/repo/grades.py
@@ -1,0 +1,20 @@
+from typing import Tuple, Optional
+
+
+def sql_select_submission_grade(db_cursor, course_id: str, assignment_id: str, student_email: str) -> Optional[Tuple[int]]:
+    db_cursor.execute(
+        "SELECT grade FROM course_assignments_submissions WHERE courseid = %s AND assid = %s AND email = %s",
+        (course_id, assignment_id, student_email),
+    )
+    return db_cursor.fetchone()
+
+
+def sql_update_submission_grade(db_cursor, grade: str | int, comment: Optional[str], user_email: str, course_id: str, assignment_id: str, student_email: str) -> None:
+    db_cursor.execute(
+        """
+        UPDATE course_assignments_submissions
+        SET grade = %s, comment = %s, gradedby = %s
+        WHERE courseid = %s AND assid = %s AND email = %s
+        """,
+        (grade, comment, user_email, course_id, assignment_id, student_email),
+    )

--- a/backend/repo/grades.py
+++ b/backend/repo/grades.py
@@ -1,4 +1,4 @@
-from typing import Tuple, Optional
+from typing import List, Tuple, Optional
 
 
 def sql_select_submission_grade(db_cursor, course_id: str, assignment_id: str, student_email: str) -> Optional[Tuple[int]]:
@@ -18,3 +18,11 @@ def sql_update_submission_grade(db_cursor, grade: str | int, comment: Optional[s
         """,
         (grade, comment, user_email, course_id, assignment_id, student_email),
     )
+
+
+def sql_select_students_grades(db_cursor, course_id: str, student_email: str) -> List[Optional[int]]:
+    db_cursor.execute(
+        "SELECT grade FROM course_assignments_submissions WHERE courseid = %s AND email = %s ORDER BY assid",
+        (course_id, student_email),
+    )
+    return [elem[0] for elem in db_cursor.fetchall()]

--- a/backend/repo/grades.py
+++ b/backend/repo/grades.py
@@ -1,4 +1,4 @@
-from typing import List, Tuple, Optional
+from typing import Tuple, Optional
 
 
 def sql_select_submission_grade(db_cursor, course_id: str, assignment_id: str, student_email: str) -> Optional[Tuple[int]]:

--- a/backend/repo/grades.py
+++ b/backend/repo/grades.py
@@ -18,11 +18,3 @@ def sql_update_submission_grade(db_cursor, grade: str | int, comment: Optional[s
         """,
         (grade, comment, user_email, course_id, assignment_id, student_email),
     )
-
-
-def sql_select_students_grades(db_cursor, course_id: str, student_email: str) -> List[Optional[int]]:
-    db_cursor.execute(
-        "SELECT grade FROM course_assignments_submissions WHERE courseid = %s AND email = %s ORDER BY assid",
-        (course_id, student_email),
-    )
-    return [elem[0] for elem in db_cursor.fetchall()]

--- a/backend/repo/grades.py
+++ b/backend/repo/grades.py
@@ -9,7 +9,7 @@ def sql_select_submission_grade(db_cursor, course_id: str, assignment_id: str, s
     return db_cursor.fetchone()
 
 
-def sql_update_submission_grade(db_cursor, grade: str | int, comment: Optional[str], user_email: str, course_id: str, assignment_id: str, student_email: str) -> None:
+def sql_update_submission_grade(db_cursor, grade: int, comment: Optional[str], user_email: str, course_id: str, assignment_id: str, student_email: str) -> None:
     db_cursor.execute(
         """
         UPDATE course_assignments_submissions

--- a/backend/repo/grades.py
+++ b/backend/repo/grades.py
@@ -1,4 +1,4 @@
-from typing import Tuple, Optional
+from typing import List, Tuple, Optional
 
 
 def sql_select_submission_grade(db_cursor, course_id: str, assignment_id: str, student_email: str) -> Optional[Tuple[int]]:
@@ -18,3 +18,27 @@ def sql_update_submission_grade(db_cursor, grade: str | int, comment: Optional[s
         """,
         (grade, comment, user_email, course_id, assignment_id, student_email),
     )
+
+def sql_select_student_grades(db_cursor, course_id: str, student_email: str) -> List[str, int, Optional[int], Optional[str], Optional[str], Optional[str]]:
+    db_cursor.execute(
+        """
+        SELECT 
+            ass.name AS assignment_name,
+            ass.assid AS assignment_id,
+            sbmt.grade,
+            sbmt.comment,
+            tch.publicname AS grader_name,
+            sbmt.gradedby AS grader_email
+        FROM course_assignments ass
+        LEFT JOIN course_assignments_submissions sbmt
+            ON ass.courseid = sbmt.courseid
+           AND ass.assid = sbmt.assid
+           AND sbmt.email = %s
+        LEFT JOIN users tch
+            ON sbmt.gradedby = tch.email
+        WHERE ass.courseid = %s
+        ORDER BY ass.assid
+        """,
+        (student_email, course_id),
+    )
+    return db_cursor.fetchall()

--- a/backend/repo/grades.py
+++ b/backend/repo/grades.py
@@ -42,3 +42,26 @@ def sql_select_student_grades(db_cursor, course_id: str, student_email: str) -> 
         (student_email, course_id),
     )
     return db_cursor.fetchall()
+
+def sql_select_all_grades(db_cursor, course_id: str) -> List[Tuple[str, str, int, str, Optional[int]]]:
+    db_cursor.execute(
+        """
+        SELECT 
+            st.email AS student_email,
+            u.publicname AS student_name,
+            ass.assid AS assignment_id,
+            ass.name AS assignment_name,
+            sbmt.grade
+        FROM student_at st
+        JOIN users u ON st.email = u.email
+        JOIN course_assignments ass ON ass.courseid = st.courseid
+        LEFT JOIN course_assignments_submissions sbmt
+            ON sbmt.courseid = ass.courseid
+           AND sbmt.assid = ass.assid
+           AND sbmt.email = st.email
+        WHERE st.courseid = %s
+        ORDER BY u.publicname, st.email, ass.assid;
+        """,
+        (course_id,)
+    )
+    return db_cursor.fetchall()

--- a/backend/repo/students.py
+++ b/backend/repo/students.py
@@ -9,6 +9,7 @@ def sql_select_enrolled_students(db_cursor, course_id: str) -> List[Tuple[str, s
         FROM student_at s
         JOIN users u ON s.email = u.email
         WHERE s.courseid = %s
+        ORDER BY u.publicname, s.email
         """,
         (course_id,),
     )

--- a/backend/repo/submissions.py
+++ b/backend/repo/submissions.py
@@ -2,13 +2,6 @@ from typing import List, Tuple, Optional
 from uuid import UUID
 from datetime import datetime
 
-def sql_select_submission_grade(db_cursor, course_id: str, assignment_id: str, student_email: str) -> Optional[Tuple[int]]:
-    db_cursor.execute(
-        "SELECT grade FROM course_assignments_submissions WHERE courseid = %s AND assid = %s AND email = %s",
-        (course_id, assignment_id, student_email),
-    )
-    return db_cursor.fetchone()
-
 
 def sql_insert_submission(db_cursor, course_id: str, assignment_id: str, student_email: str, submission_text: str) -> None:
     db_cursor.execute(
@@ -105,14 +98,3 @@ def sql_select_single_submission(db_cursor, course_id: str, assignment_id: str, 
         (course_id, assignment_id, student_email),
     )
     return db_cursor.fetchone()
-
-
-def sql_update_submission_grade(db_cursor, grade: str | int, comment: Optional[str], user_email: str, course_id: str, assignment_id: str, student_email: str) -> None:
-    db_cursor.execute(
-        """
-        UPDATE course_assignments_submissions
-        SET grade = %s, comment = %s, gradedby = %s
-        WHERE courseid = %s AND assid = %s AND email = %s
-        """,
-        (grade, comment, user_email, course_id, assignment_id, student_email),
-    )

--- a/backend/repo/submissions.py
+++ b/backend/repo/submissions.py
@@ -57,20 +57,22 @@ def sql_update_submission_text(db_cursor, submission_text: str, course_id: str, 
     )
 
 
-def sql_select_submissions(db_cursor, course_id: str, assignment_id: str) -> List[Tuple[str, str, datetime, datetime, str, Optional[int], Optional[str], Optional[str]]]:
+def sql_select_submissions(db_cursor, course_id: str, assignment_id: str) -> List[Tuple[str, str, datetime, datetime, str, Optional[int], Optional[str], Optional[str], Optional[str]]]:
     db_cursor.execute(
         """
         SELECT
             s.email,
-            u.publicname,
+            st.publicname,
             s.timeadded,
             s.timemodified,
             s.submissiontext,
             s.grade,
             s.comment,
-            s.gradedby
+            s.gradedby,
+            tch.publicname
         FROM course_assignments_submissions s
-        JOIN users u ON s.email = u.email
+        JOIN users st ON s.email = st.email
+        JOIN users tch ON s.gradedby = tch.email
         WHERE s.courseid = %s AND s.assid = %s
         ORDER BY s.timeadded DESC
         """,
@@ -79,20 +81,22 @@ def sql_select_submissions(db_cursor, course_id: str, assignment_id: str) -> Lis
     return db_cursor.fetchall()
 
 
-def sql_select_single_submission(db_cursor, course_id: str, assignment_id: str, student_email: str) -> Tuple[str, str, datetime, datetime, str, Optional[int], Optional[str], Optional[str]]:
+def sql_select_single_submission(db_cursor, course_id: str, assignment_id: str, student_email: str) -> Tuple[str, str, datetime, datetime, str, Optional[int], Optional[str], Optional[str], Optional[str]]:
     db_cursor.execute(
         """
         SELECT
             s.email,
-            u.publicname,
+            st.publicname,
             s.timeadded,
             s.timemodified,
             s.submissiontext,
             s.grade,
             s.comment,
-            s.gradedby
+            s.gradedby,
+            tch.publicname
         FROM course_assignments_submissions s
-        JOIN users u ON s.email = u.email
+        JOIN users st ON s.email = st.email
+        JOIN users tch ON s.gradedby = tch.email
         WHERE s.courseid = %s AND s.assid = %s AND s.email = %s
         """,
         (course_id, assignment_id, student_email),

--- a/backend/repo/submissions.py
+++ b/backend/repo/submissions.py
@@ -72,7 +72,7 @@ def sql_select_submissions(db_cursor, course_id: str, assignment_id: str) -> Lis
             tch.publicname
         FROM course_assignments_submissions s
         JOIN users st ON s.email = st.email
-        JOIN users tch ON s.gradedby = tch.email
+        LEFT JOIN users tch ON s.gradedby = tch.email
         WHERE s.courseid = %s AND s.assid = %s
         ORDER BY s.timeadded DESC
         """,
@@ -96,7 +96,7 @@ def sql_select_single_submission(db_cursor, course_id: str, assignment_id: str, 
             tch.publicname
         FROM course_assignments_submissions s
         JOIN users st ON s.email = st.email
-        JOIN users tch ON s.gradedby = tch.email
+        LEFT JOIN users tch ON s.gradedby = tch.email
         WHERE s.courseid = %s AND s.assid = %s AND s.email = %s
         """,
         (course_id, assignment_id, student_email),

--- a/backend/repo/submissions.py
+++ b/backend/repo/submissions.py
@@ -81,7 +81,7 @@ def sql_select_submissions(db_cursor, course_id: str, assignment_id: str) -> Lis
     return db_cursor.fetchall()
 
 
-def sql_select_single_submission(db_cursor, course_id: str, assignment_id: str, student_email: str) -> Tuple[str, str, datetime, datetime, str, Optional[int], Optional[str], Optional[str], Optional[str]]:
+def sql_select_single_submission(db_cursor, course_id: str, assignment_id: str, student_email: str) -> Optional[Tuple[str, str, datetime, datetime, str, Optional[int], Optional[str], Optional[str], Optional[str]]]:
     db_cursor.execute(
         """
         SELECT

--- a/backend/routers/assignments.py
+++ b/backend/routers/assignments.py
@@ -77,6 +77,7 @@ async def get_assignment(course_id: str, assignment_id: str, user_email: str = D
         return logic.assignments.get_assignment(db_cursor, course_id, assignment_id, user_email)
 
 
+# TODO: tests
 @router.get("/get_course_assignments", response_model=List[json_classes.Assignment], tags=["Assignments"])
 async def get_course_assignments(course_id: str, user_email: str = Depends(get_current_user)):
     """

--- a/backend/routers/assignments.py
+++ b/backend/routers/assignments.py
@@ -75,7 +75,8 @@ async def get_assignment(course_id: str, assignment_id: str, user_email: str = D
     # connection to database
     with get_db() as (db_conn, db_cursor):
         return logic.assignments.get_assignment(db_cursor, course_id, assignment_id, user_email)
-    
+
+
 @router.get("/get_course_assignments", response_model=List[json_classes.Assignment], tags=["Assignments"])
 async def get_course_assignments(course_id: str, user_email: str = Depends(get_current_user)):
     """

--- a/backend/routers/assignments.py
+++ b/backend/routers/assignments.py
@@ -77,7 +77,6 @@ async def get_assignment(course_id: str, assignment_id: str, user_email: str = D
         return logic.assignments.get_assignment(db_cursor, course_id, assignment_id, user_email)
 
 
-# TODO: tests
 @router.get("/get_course_assignments", response_model=List[json_classes.Assignment], tags=["Assignments"])
 async def get_course_assignments(course_id: str, user_email: str = Depends(get_current_user)):
     """

--- a/backend/routers/assignments.py
+++ b/backend/routers/assignments.py
@@ -75,6 +75,24 @@ async def get_assignment(course_id: str, assignment_id: str, user_email: str = D
     # connection to database
     with get_db() as (db_conn, db_cursor):
         return logic.assignments.get_assignment(db_cursor, course_id, assignment_id, user_email)
+    
+@router.get("/get_course_assignments", response_model=List[json_classes.Assignment], tags=["Assignments"])
+async def get_course_assignments(course_id: str, user_email: str = Depends(get_current_user)):
+    """
+    Get the list of course assignments by the provided course_id.
+
+    For each assignment, it returns course_id, assignment_id, creation_time, title, description, and email of the author.
+
+    Author can be NULL if the author deleted their account.
+
+    The format of creation time is TIME_FORMAT.
+
+    Course role (Primary Instructor, Teacher, Student, Parent) required.
+    """
+
+    # connection to database
+    with get_db() as (db_conn, db_cursor):
+        return logic.assignments.get_course_assignments(db_cursor, course_id, user_email)
 
 
 @router.post("/create_assignment_attachment", response_model=json_classes.AssignmentAttachmentMetadata, tags=["Assignments"])

--- a/backend/routers/courses.py
+++ b/backend/routers/courses.py
@@ -8,7 +8,7 @@ import logic.courses
 router = APIRouter()
 
 
-@router.get("/available_courses", response_model=List[json_classes.CourseId], tags=["Courses"])
+@router.get("/available_courses", response_model=List[json_classes.CourseID], tags=["Courses"])
 async def available_courses(user_email: str = Depends(get_current_user)):
     """
     Get the list of IDs of courses available for user (as a Primary Instructor, Teacher, Student, or Parent).
@@ -17,7 +17,7 @@ async def available_courses(user_email: str = Depends(get_current_user)):
         return logic.courses.available_courses(db_cursor, user_email)
 
 
-@router.get("/get_all_courses", response_model=List[json_classes.CourseId], tags=["Courses"])
+@router.get("/get_all_courses", response_model=List[json_classes.CourseID], tags=["Courses"])
 async def get_all_courses(user_email: str = Depends(get_current_user)):
     """
     Get the list of IDs of all courses in the system.
@@ -28,7 +28,7 @@ async def get_all_courses(user_email: str = Depends(get_current_user)):
         return logic.courses.get_all_courses(db_cursor, user_email)
 
 
-@router.post("/create_course", response_model=json_classes.CourseId, tags=["Courses"])
+@router.post("/create_course", response_model=json_classes.CourseID, tags=["Courses"])
 async def create_course(
     title: str = Query(
         ...,

--- a/backend/routers/grades.py
+++ b/backend/routers/grades.py
@@ -44,8 +44,6 @@ async def grade_submission(
         )
 
 
-# TODO: write get_coruse_assignments (для таблицы) в routers/assignments.py и logic/assignments.py
-# TODO: write tests
 @router.get("/get_all_course_grades", response_model=List[json_classes.StudentsGrades], tags=["Grades"])
 async def get_all_course_grades(
     course_id: str,
@@ -56,7 +54,7 @@ async def get_all_course_grades(
 
     Teacher OR Primary Instructor role required.
 
-    Returns the list where each row corresponds to some student.
+    Returns the list where each row corresponds to some student (students are sorted in the alphabetical order (first by user name, then by email)).
 
     Each row has the following format: {name: str, email: str, grades: List[Optional[int]]}
 
@@ -68,7 +66,6 @@ async def get_all_course_grades(
         return logic.grades.get_all_course_grades(db_cursor, course_id, user_email)
 
 
-# TODO: write tests
 @router.get("/get_student_course_grades", response_model=List[json_classes.AssignmentGrade], tags=["Grades"])
 async def get_student_course_grades(
     course_id: str,

--- a/backend/routers/grades.py
+++ b/backend/routers/grades.py
@@ -1,0 +1,44 @@
+from typing import Optional
+from fastapi import APIRouter, Depends, Query
+from auth import get_current_user, get_db
+import json_classes
+import logic.grades
+
+
+router = APIRouter()
+
+
+@router.post("/grade_submission", response_model=json_classes.Success, tags=["Grades"])
+async def grade_submission(
+    course_id: str,
+    assignment_id: str,
+    student_email: str,
+    grade: str,
+    comment: Optional[str] = Query(
+        None,
+        min_length=3,
+        max_length=10000,
+        description="Comment must contain 3-10000 symbols"
+    ),
+    user_email: str = Depends(get_current_user),
+):
+    """
+    Allows teacher to grade student's submission.
+
+    Teacher OR Primary Instructor role required.
+
+    Comment must be None or contain from 3 to 10000 symbols.
+    """
+
+    # connection to database
+    with get_db() as (db_conn, db_cursor):
+        return logic.grades.grade_submission(
+            db_conn,
+            db_cursor,
+            course_id,
+            assignment_id,
+            student_email,
+            grade,
+            comment,
+            user_email
+        )

--- a/backend/routers/grades.py
+++ b/backend/routers/grades.py
@@ -13,7 +13,7 @@ async def grade_submission(
     course_id: str,
     assignment_id: str,
     student_email: str,
-    grade: str,
+    grade: int,
     comment: Optional[str] = Query(
         None,
         min_length=3,

--- a/backend/routers/grades.py
+++ b/backend/routers/grades.py
@@ -1,4 +1,4 @@
-from typing import Optional
+from typing import Optional, List
 from fastapi import APIRouter, Depends, Query
 from auth import get_current_user, get_db
 import json_classes
@@ -42,3 +42,53 @@ async def grade_submission(
             comment,
             user_email
         )
+
+
+# TODO: write get_coruse_assignments (для таблицы) в routers/assignments.py и logic/assignments.py
+# TODO: write tests
+@router.get("/get_all_course_grades", response_model=List[json_classes.StudentsGrades], tags=["Grades"])
+async def get_all_course_grades(
+    course_id: str,
+    user_email: str = Depends(get_current_user)
+):
+    """
+    Get the table of all course grades.
+
+    Teacher OR Primary Instructor role required.
+
+    Returns the list where each row corresponds to some student.
+
+    Each row has the following format: {name: str, email: str, grades: List[Optional[int]]}
+
+    Grades list can contain `null` values if the assignment was not graded yet.    
+    """
+
+    # connection to database
+    with get_db() as (db_conn, db_cursor):
+        return logic.grades.get_all_course_grades(db_cursor, course_id, user_email)
+
+
+# TODO: write tests
+@router.get("/get_student_course_grades", response_model=List[json_classes.AssignmentGrade], tags=["Grades"])
+async def get_student_course_grades(
+    course_id: str,
+    student_email: str,
+    user_email: str = Depends(get_current_user)
+):
+    """
+    Get the table of course grades of student with provided student_email.
+
+    - Teacher AND Primary Instructor can get grades of every student.
+    - Parent can get the grades of their student
+    - Student can get their grades
+
+    Returns the list where each row corresponds to some assignment.
+
+    Each row has the following format: {assignment_name: str, assignment_id: int, grade: Optional[int], comment: Optional[str], grader_name: Optional[str], grader_email: Optional[str]}
+
+    `grade`, `comment`, `grader_name`, and `grader_email` can be `null` if the assignment was not graded yet. 
+    """
+
+    # connection to database
+    with get_db() as (db_conn, db_cursor):
+        return logic.grades.get_student_course_grades(db_cursor, course_id, student_email, user_email)

--- a/backend/routers/grades.py
+++ b/backend/routers/grades.py
@@ -75,7 +75,7 @@ async def get_student_course_grades(
     """
     Get the table of course grades of student with provided student_email.
 
-    - Teacher AND Primary Instructor can get grades of every student.
+    - Teacher OR Primary Instructor can get grades of every student.
     - Parent can get the grades of their student
     - Student can get their grades
 

--- a/backend/routers/students.py
+++ b/backend/routers/students.py
@@ -13,6 +13,8 @@ async def get_enrolled_students(course_id: str, user_email: str = Depends(get_cu
     """
     Get the list of enrolled students by course_id.
 
+    Students are sorted in the alphabetical order (first by user name, then by email).
+
     Return the email and name of each student.
 
     Course role (Primary Instructor, Teacher, Student, Parent) required.

--- a/backend/routers/submissions.py
+++ b/backend/routers/submissions.py
@@ -44,7 +44,7 @@ async def get_assignment_submissions(course_id: str, assignment_id: str, user_em
 
     Submissions are ordered by submission_time, newest submissions go first.
 
-    Returns the list of submissions (course_id, assignment_id, student_email, student_name, submission_time, last_modification_time, submission_text, grade, comment, gradedby_email).
+    Returns the list of submissions (course_id, assignment_id, student_email, student_name, submission_time, last_modification_time, submission_text, grade, comment, gradedby_email, gradedby_name).
 
     The format of submission_time and last_modification_time is TIME_FORMAT.
 
@@ -70,7 +70,7 @@ async def get_submission(
     - Parent can get the submission of their student
     - Student can get their submissions
 
-    Returns the submission (course_id, assignment_id, student_email, student_name, submission_time, last_modification_time, submission_text, grade, comment, gradedby_email).
+    Returns the submission (course_id, assignment_id, student_email, student_name, submission_time, last_modification_time, submission_text, grade, comment, gradedby_email, gradedby_name).
 
     The format of submission_time and last_modification_time is TIME_FORMAT.
 

--- a/backend/routers/submissions.py
+++ b/backend/routers/submissions.py
@@ -66,7 +66,7 @@ async def get_submission(
     """
     Get the student submission of assignment by course_id, assignment_id and student_email.
 
-    - Teacher AND Primary Instructor can get all submissions of the course
+    - Teacher OR Primary Instructor can get all submissions of the course
     - Parent can get the submission of their student
     - Student can get their submissions
 
@@ -110,7 +110,7 @@ async def get_submission_attachments(course_id: str, assignment_id: str, student
     """
     Get the list of attachments to the course assignment submission by provided course_id, assignment_id, student_email.
 
-    - Teacher AND Primary Instructor can get all submission attachments of the course
+    - Teacher OR Primary Instructor can get all submission attachments of the course
     - Parent can get the submission attachments of their student
     - Student can get their submission attachments
     

--- a/backend/routers/submissions.py
+++ b/backend/routers/submissions.py
@@ -1,4 +1,4 @@
-from typing import List, Optional
+from typing import List
 from fastapi import APIRouter, Depends, Query, UploadFile, File
 from auth import get_current_user, get_db, get_storage_db
 import json_classes
@@ -80,42 +80,6 @@ async def get_submission(
     # connection to database
     with get_db() as (db_conn, db_cursor):
         return logic.submissions.get_submission(db_cursor, course_id, assignment_id, student_email, user_email)
-
-
-@router.post("/grade_submission", response_model=json_classes.Success, tags=["Submissions"])
-async def grade_submission(
-    course_id: str,
-    assignment_id: str,
-    student_email: str,
-    grade: str,
-    comment: Optional[str] = Query(
-        None,
-        min_length=3,
-        max_length=10000,
-        description="Comment must contain 3-10000 symbols"
-    ),
-    user_email: str = Depends(get_current_user),
-):
-    """
-    Allows teacher to grade student's submission.
-
-    Teacher OR Primary Instructor role required.
-
-    Comment must be None or contain from 3 to 10000 symbols.
-    """
-
-    # connection to database
-    with get_db() as (db_conn, db_cursor):
-        return logic.submissions.grade_submission(
-            db_conn,
-            db_cursor,
-            course_id,
-            assignment_id,
-            student_email,
-            grade,
-            comment,
-            user_email
-        )
 
 
 @router.post("/create_submission_attachment", response_model=json_classes.SubmissionAttachmentMetadata, tags=["Submissions"])

--- a/backend/routers/users.py
+++ b/backend/routers/users.py
@@ -65,7 +65,7 @@ async def change_password(user: json_classes.UserNewPassword):
         return logic.users.change_password(db_conn, db_cursor, user)
 
 
-@router.get("/get_instructor_courses", response_model=List[json_classes.CourseId], tags=["Users"])
+@router.get("/get_instructor_courses", response_model=List[json_classes.CourseID], tags=["Users"])
 async def get_instructor_courses(user_email: str = Depends(get_current_user)):
     """
     Get the list of IDs of courses where the provided user is a Primary Instructor.

--- a/backend/tests/courses.sh
+++ b/backend/tests/courses.sh
@@ -179,6 +179,18 @@ json_partial_match_test "Request the assignment info from Alice" "$info" "$expec
 
 # --------------------------------------------------------------------
 
+info=$(curl -s -X GET \
+    -H "Authorization: Bearer $TOKEN" \
+    "$API_URL/get_course_assignments?course_id=$mathcourseid")
+
+expected='[
+    {"course_id":"'"$mathcourseid"'","assignment_id":'$assignmentid',"title":"Assignment 1","description":"To do exercise 10 from the course book","author":"alice@example.com"}
+]'
+
+json_partial_match_test "Request the assignment info from Alice" "$info" "$expected" "assignment_id" "creation_time"
+
+# --------------------------------------------------------------------
+
 login_and_get_token "Login as Bob" \
     -X POST $API_URL/login \
     -H "Content-Type: application/json" \

--- a/backend/tests/grades.sh
+++ b/backend/tests/grades.sh
@@ -87,10 +87,10 @@ info=$(curl -s -X GET \
 
 expected='[
     {"assignment_name":"Assignment 1","assignment_id":'$firstassignmentid',"grade":null,"comment":null,"grader_name":null,"grader_email":null},
-    {"assignment_name":"Assignment 2","assignment_id":'$secondassignmentid',"grade":null,"comment":null,"grader_name":null,"grader_email":null},
+    {"assignment_name":"Assignment 2","assignment_id":'$secondassignmentid',"grade":null,"comment":null,"grader_name":null,"grader_email":null}
 ]'
 
-json_exact_match_test "Request Bob's assignment grades from Bob" "$info" "$expected" "assignment_id"
+json_exact_match_test "Request Bob's assignment grades from Bob" "$info" "$expected" "assignment_name"
 
 # --------------------------------------------------------------------
 
@@ -141,7 +141,7 @@ info=$(curl -s -X GET \
 
 expected='[
     {"assignment_name":"Assignment 1","assignment_id":'$firstassignmentid',"grade":null,"comment":null,"grader_name":null,"grader_email":null},
-    {"assignment_name":"Assignment 2","assignment_id":'$secondassignmentid',"grade":null,"comment":null,"grader_name":null,"grader_email":null},
+    {"assignment_name":"Assignment 2","assignment_id":'$secondassignmentid',"grade":null,"comment":null,"grader_name":null,"grader_email":null}
 ]'
 
 json_exact_match_test "Request the Bob's assignment grades from Eugene" "$info" "$expected" "assignment_id"

--- a/backend/tests/grades.sh
+++ b/backend/tests/grades.sh
@@ -54,6 +54,9 @@ secondassignmentid=$(curl -s -X POST \
     -H "Authorization: Bearer $TOKEN" \
     "$API_URL/create_assignment?course_id=$mathcourseid&title=Assignment%202&description=To%20do%20exercise%2020%20from%20the%20course%20book" | extract_field assignment_id)
 
+echo "firstassignmentid=$firstassignmentid"
+echo "secondassignmentid=$secondassignmentid"
+
 # --------------------------------------------------------------------
 
 success_test "Invite Bob to Alice's course as a student" \
@@ -89,6 +92,9 @@ expected='[
     {"assignment_name":"Assignment 1","assignment_id":'$firstassignmentid',"grade":null,"comment":null,"grader_name":null,"grader_email":null},
     {"assignment_name":"Assignment 2","assignment_id":'$secondassignmentid',"grade":null,"comment":null,"grader_name":null,"grader_email":null}
 ]'
+
+echo $expected
+echo "$expected" | jq .
 
 json_exact_match_test "Request Bob's assignment grades from Bob" "$info" "$expected" "assignment_name"
 

--- a/backend/tests/grades.sh
+++ b/backend/tests/grades.sh
@@ -96,6 +96,9 @@ expected='[
 echo $expected
 echo "$expected" | jq .
 
+echo $info
+echo "$info" | jq .
+
 json_exact_match_test "Request Bob's assignment grades from Bob" "$info" "$expected" "assignment_name"
 
 # --------------------------------------------------------------------

--- a/backend/tests/grades.sh
+++ b/backend/tests/grades.sh
@@ -54,9 +54,6 @@ secondassignmentid=$(curl -s -X POST \
     -H "Authorization: Bearer $TOKEN" \
     "$API_URL/create_assignment?course_id=$mathcourseid&title=Assignment%202&description=To%20do%20exercise%2020%20from%20the%20course%20book" | extract_field assignment_id)
 
-echo "firstassignmentid=$firstassignmentid"
-echo "secondassignmentid=$secondassignmentid"
-
 # --------------------------------------------------------------------
 
 success_test "Invite Bob to Alice's course as a student" \
@@ -87,8 +84,6 @@ success_test "Submit assignment as Bob" \
 info=$(curl -s -X GET \
     -H "Authorization: Bearer $TOKEN" \
     "$API_URL/get_student_course_grades?course_id=$mathcourseid&student_email=bob@example.com")
-
-echo "$expected" | jq .
 
 expected='[
     {"assignment_name":"Assignment 1","assignment_id":'$firstassignmentid',"grade":null,"comment":null,"grader_name":null,"grader_email":null},

--- a/backend/tests/grades.sh
+++ b/backend/tests/grades.sh
@@ -54,9 +54,6 @@ secondassignmentid=$(curl -s -X POST \
     -H "Authorization: Bearer $TOKEN" \
     "$API_URL/create_assignment?course_id=$mathcourseid&title=Assignment%202&description=To%20do%20exercise%2020%20from%20the%20course%20book" | extract_field assignment_id)
 
-echo "firstassignmentid=$firstassignmentid"
-echo "secondassignmentid=$secondassignmentid"
-
 # --------------------------------------------------------------------
 
 success_test "Invite Bob to Alice's course as a student" \
@@ -92,9 +89,6 @@ expected='[
     {"assignment_name":"Assignment 1","assignment_id":'$firstassignmentid',"grade":null,"comment":null,"grader_name":null,"grader_email":null},
     {"assignment_name":"Assignment 2","assignment_id":'$secondassignmentid',"grade":null,"comment":null,"grader_name":null,"grader_email":null}
 ]'
-
-echo $expected
-echo "$expected" | jq .
 
 json_exact_match_test "Request Bob's assignment grades from Bob" "$info" "$expected" "assignment_name"
 

--- a/backend/tests/grades.sh
+++ b/backend/tests/grades.sh
@@ -1,0 +1,180 @@
+#!/bin/bash
+set -euo pipefail
+
+API_URL="http://localhost:8000"
+
+source ./backend/tests/common_functions.sh
+
+# --------------------------------------------------------------------
+
+success_test "Registration of Alice" \
+    -X POST $API_URL/create_user \
+    -H "Content-Type: application/json" \
+    -d "{\"email\":\"alice@example.com\",\"password\":\"alicePass123!\",\"name\":\"Alice\"}"
+
+# --------------------------------------------------------------------
+
+success_test "Registration of Bob" \
+    -X POST $API_URL/create_user \
+    -H "Content-Type: application/json" \
+    -d "{\"email\":\"bob@example.com\",\"password\":\"bobPass123!\",\"name\":\"Bob\"}"
+
+# --------------------------------------------------------------------
+
+success_test "Registration of Charlie" \
+    -X POST $API_URL/create_user \
+    -H "Content-Type: application/json" \
+    -d "{\"email\":\"charlie@example.com\",\"password\":\"charliePass123!\",\"name\":\"Charlie\"}"
+
+# --------------------------------------------------------------------
+
+success_test "Registration of Eugene" \
+    -X POST $API_URL/create_user \
+    -H "Content-Type: application/json" \
+    -d "{\"email\":\"eugene@example.com\",\"password\":\"eugenePass123!\",\"name\":\"Eugene\"}"
+
+# --------------------------------------------------------------------
+
+login_and_get_token "Login as Alice" \
+    -X POST $API_URL/login \
+    -H "Content-Type: application/json" \
+    -d "{\"email\":\"alice@example.com\",\"password\":\"alicePass123!\"}"
+
+# --------------------------------------------------------------------
+
+mathcourseid=$(curl -s -X POST \
+    -H "Authorization: Bearer $TOKEN" \
+    "$API_URL/create_course?title=Math&organization=Innopolis%20University" | extract_field course_id)
+
+firstassignmentid=$(curl -s -X POST \
+    -H "Authorization: Bearer $TOKEN" \
+    "$API_URL/create_assignment?course_id=$mathcourseid&title=Assignment%201&description=To%20do%20exercise%2010%20from%20the%20course%20book" | extract_field assignment_id)
+
+secondassignmentid=$(curl -s -X POST \
+    -H "Authorization: Bearer $TOKEN" \
+    "$API_URL/create_assignment?course_id=$mathcourseid&title=Assignment%202&description=To%20do%20exercise%2020%20from%20the%20course%20book" | extract_field assignment_id)
+
+# --------------------------------------------------------------------
+
+success_test "Invite Bob to Alice's course as a student" \
+    -X POST "$API_URL/invite_student?course_id=$mathcourseid&student_email=bob@example.com" \
+    -H "Authorization: Bearer $TOKEN" \
+
+success_test "Invite Charlie to Alice's course as a student" \
+    -X POST "$API_URL/invite_student?course_id=$mathcourseid&student_email=charlie@example.com" \
+    -H "Authorization: Bearer $TOKEN" \
+
+success_test "Invite Eugene to Alice's course as Bob's parent" \
+    -X POST "$API_URL/invite_parent?course_id=$mathcourseid&student_email=bob@example.com&parent_email=eugene@example.com" \
+    -H "Authorization: Bearer $TOKEN" \
+
+# --------------------------------------------------------------------
+
+login_and_get_token "Login as Bob" \
+    -X POST $API_URL/login \
+    -H "Content-Type: application/json" \
+    -d "{\"email\":\"bob@example.com\",\"password\":\"bobPass123!\"}"
+
+success_test "Submit assignment as Bob" \
+    -X POST "$API_URL/submit_assignment?course_id=$mathcourseid&assignment_id=$firstassignmentid&submission_text=The%20answer%20is%2010" \
+    -H "Authorization: Bearer $TOKEN" \
+
+# --------------------------------------------------------------------
+
+info=$(curl -s -X GET \
+    -H "Authorization: Bearer $TOKEN" \
+    "$API_URL/get_student_course_grades?course_id=$mathcourseid&student_email=bob@example.com")
+
+expected='[
+    {"assignment_name":"Assignment 1","assignment_id":'$firstassignmentid',"grade":null,"comment":null,"grader_name":null,"grader_email":null},
+    {"assignment_name":"Assignment 2","assignment_id":'$secondassignmentid',"grade":null,"comment":null,"grader_name":null,"grader_email":null},
+]'
+
+json_exact_match_test "Request Bob's assignment grades from Bob" "$info" "$expected" "assignment_id"
+
+# --------------------------------------------------------------------
+
+fail_test "Request all course grades from Bob (student)" \
+    -X POST "$API_URL/get_all_course_grades?course_id=$mathcourseid" \
+    -H "Authorization: Bearer $TOKEN" \
+
+fail_test "Request Charlie's assignment grades from Bob" \
+    -X POST "$API_URL/get_student_course_grades?course_id=$mathcourseid&student_email=charlie@example.com" \
+    -H "Authorization: Bearer $TOKEN" \
+
+fail_test "Request Eugene's assignment grades from Bob" \
+    -X POST "$API_URL/get_student_course_grades?course_id=$mathcourseid&student_email=eugene@example.com" \
+    -H "Authorization: Bearer $TOKEN" \
+
+# --------------------------------------------------------------------
+
+login_and_get_token "Login as Alice" \
+    -X POST $API_URL/login \
+    -H "Content-Type: application/json" \
+    -d "{\"email\":\"alice@example.com\",\"password\":\"alicePass123!\"}"
+
+# --------------------------------------------------------------------
+
+info=$(curl -s -X GET \
+    -H "Authorization: Bearer $TOKEN" \
+    "$API_URL/get_all_course_grades?course_id=$mathcourseid")
+
+expected='[
+    {"name":"Bob","email":"bob@example.com","grades":[null,null]},
+    {"name":"Charlie","email":"charlie@example.com","grades":[null,null]}
+]'
+
+json_exact_match_test "Request all course grades from Alice" "$info" "$expected" "email"
+
+# --------------------------------------------------------------------
+
+login_and_get_token "Login as Eugene" \
+    -X POST $API_URL/login \
+    -H "Content-Type: application/json" \
+    -d "{\"email\":\"eugene@example.com\",\"password\":\"eugenePass123!\"}"
+
+# --------------------------------------------------------------------
+
+info=$(curl -s -X GET \
+    -H "Authorization: Bearer $TOKEN" \
+    "$API_URL/get_student_course_grades?course_id=$mathcourseid&student_email=bob@example.com")
+
+expected='[
+    {"assignment_name":"Assignment 1","assignment_id":'$firstassignmentid',"grade":null,"comment":null,"grader_name":null,"grader_email":null},
+    {"assignment_name":"Assignment 2","assignment_id":'$secondassignmentid',"grade":null,"comment":null,"grader_name":null,"grader_email":null},
+]'
+
+json_exact_match_test "Request the Bob's assignment grades from Eugene" "$info" "$expected" "assignment_id"
+
+# --------------------------------------------------------------------
+
+fail_test "Request all course grades from Eugene (parent)" \
+    -X POST "$API_URL/get_all_course_grades?course_id=$mathcourseid" \
+    -H "Authorization: Bearer $TOKEN" \
+
+fail_test "Request Charlie's assignment grades from Eugene" \
+    -X POST "$API_URL/get_student_course_grades?course_id=$mathcourseid&student_email=charlie@example.com" \
+    -H "Authorization: Bearer $TOKEN" \
+
+# --------------------------------------------------------------------
+
+login_and_get_token "Login as Admin" \
+    -X POST $API_URL/login \
+    -H "Content-Type: application/json" \
+    -d "{\"email\":\"admin\",\"password\":\"admin\"}"
+
+success_test "Removing Alice account from Admin" \
+    -X POST "$API_URL/remove_user?deleted_user_email=alice@example.com" \
+    -H "Authorization: Bearer $TOKEN" \
+
+success_test "Removing Bob account from Admin" \
+    -X POST "$API_URL/remove_user?deleted_user_email=bob@example.com" \
+    -H "Authorization: Bearer $TOKEN" \
+
+success_test "Removing Charlie account from Admin" \
+    -X POST "$API_URL/remove_user?deleted_user_email=charlie@example.com" \
+    -H "Authorization: Bearer $TOKEN" \
+
+success_test "Removing Eugene account from Admin" \
+    -X POST "$API_URL/remove_user?deleted_user_email=eugene@example.com" \
+    -H "Authorization: Bearer $TOKEN" \

--- a/backend/tests/grades.sh
+++ b/backend/tests/grades.sh
@@ -96,9 +96,6 @@ expected='[
 echo $expected
 echo "$expected" | jq .
 
-echo $info
-echo "$info" | jq .
-
 json_exact_match_test "Request Bob's assignment grades from Bob" "$info" "$expected" "assignment_name"
 
 # --------------------------------------------------------------------

--- a/backend/tests/grades.sh
+++ b/backend/tests/grades.sh
@@ -54,6 +54,9 @@ secondassignmentid=$(curl -s -X POST \
     -H "Authorization: Bearer $TOKEN" \
     "$API_URL/create_assignment?course_id=$mathcourseid&title=Assignment%202&description=To%20do%20exercise%2020%20from%20the%20course%20book" | extract_field assignment_id)
 
+echo "firstassignmentid=$firstassignmentid"
+echo "secondassignmentid=$secondassignmentid"
+
 # --------------------------------------------------------------------
 
 success_test "Invite Bob to Alice's course as a student" \
@@ -84,6 +87,8 @@ success_test "Submit assignment as Bob" \
 info=$(curl -s -X GET \
     -H "Authorization: Bearer $TOKEN" \
     "$API_URL/get_student_course_grades?course_id=$mathcourseid&student_email=bob@example.com")
+
+echo "$expected" | jq .
 
 expected='[
     {"assignment_name":"Assignment 1","assignment_id":'$firstassignmentid',"grade":null,"comment":null,"grader_name":null,"grader_email":null},

--- a/backend/tests/submissions.sh
+++ b/backend/tests/submissions.sh
@@ -105,7 +105,7 @@ info=$(curl -s -X GET \
     "$API_URL/get_submission?course_id=$mathcourseid&assignment_id=$assignmentid&student_email=bob@example.com")
 
 expected='
-    {"course_id":"'"$mathcourseid"'","assignment_id":'$assignmentid',"student_email":"bob@example.com","student_name":"Bob","submission_text":"The answer is 10","grade":null,"comment":null,"gradedby_email":null}
+    {"course_id":"'"$mathcourseid"'","assignment_id":'$assignmentid',"student_email":"bob@example.com","student_name":"Bob","submission_text":"The answer is 10","grade":null,"comment":null,"gradedby_email":null,"gradedby_name":null}
 '
 
 json_partial_match_test "Request the submission details from Bob" "$info" "$expected" "assignment_id" "submission_time last_modification_time"
@@ -124,7 +124,7 @@ info=$(curl -s -X GET \
     "$API_URL/get_assignment_submissions?course_id=$mathcourseid&assignment_id=$assignmentid")
 
 expected='[
-    {"course_id":"'"$mathcourseid"'","assignment_id":'$assignmentid',"student_email":"bob@example.com","student_name":"Bob","submission_text":"The answer is 10","grade":null,"comment":null,"gradedby_email":null}
+    {"course_id":"'"$mathcourseid"'","assignment_id":'$assignmentid',"student_email":"bob@example.com","student_name":"Bob","submission_text":"The answer is 10","grade":null,"comment":null,"gradedby_email":null,"gradedby_name":null}
 ]'
 
 json_partial_match_test "Request the list of assignment submissions by Alice" "$info" "$expected" "assignment_id" "submission_time last_modification_time"
@@ -136,7 +136,7 @@ info=$(curl -s -X GET \
     "$API_URL/get_submission?course_id=$mathcourseid&assignment_id=$assignmentid&student_email=bob@example.com")
 
 expected='
-    {"course_id":"'"$mathcourseid"'","assignment_id":'$assignmentid',"student_email":"bob@example.com","student_name":"Bob","submission_text":"The answer is 10","grade":null,"comment":null,"gradedby_email":null}
+    {"course_id":"'"$mathcourseid"'","assignment_id":'$assignmentid',"student_email":"bob@example.com","student_name":"Bob","submission_text":"The answer is 10","grade":null,"comment":null,"gradedby_email":null,"gradedby_name":null}
 '
 
 json_partial_match_test "Request the submission details by Alice" "$info" "$expected" "assignment_id" "submission_time last_modification_time"
@@ -154,7 +154,7 @@ info=$(curl -s -X GET \
     "$API_URL/get_submission?course_id=$mathcourseid&assignment_id=$assignmentid&student_email=bob@example.com")
 
 expected='
-    {"course_id":"'"$mathcourseid"'","assignment_id":'$assignmentid',"student_email":"bob@example.com","student_name":"Bob","submission_text":"The answer is 10","grade":5,"comment":"Good job","gradedby_email":"alice@example.com"}
+    {"course_id":"'"$mathcourseid"'","assignment_id":'$assignmentid',"student_email":"bob@example.com","student_name":"Bob","submission_text":"The answer is 10","grade":5,"comment":"Good job","gradedby_email":"alice@example.com","gradedby_name":"Alice"}
 '
 
 json_partial_match_test "Request the submission details by Alice" "$info" "$expected" "assignment_id" "submission_time last_modification_time"
@@ -173,7 +173,7 @@ info=$(curl -s -X GET \
     "$API_URL/get_submission?course_id=$mathcourseid&assignment_id=$assignmentid&student_email=bob@example.com")
 
 expected='
-    {"course_id":"'"$mathcourseid"'","assignment_id":'$assignmentid',"student_email":"bob@example.com","student_name":"Bob","submission_text":"The answer is 10","grade":5,"comment":"Good job","gradedby_email":"alice@example.com"}
+    {"course_id":"'"$mathcourseid"'","assignment_id":'$assignmentid',"student_email":"bob@example.com","student_name":"Bob","submission_text":"The answer is 10","grade":5,"comment":"Good job","gradedby_email":"alice@example.com","gradedby_name":"Alice"}
 '
 
 json_partial_match_test "Request the submission details by Charlie" "$info" "$expected" "assignment_id" "submission_time last_modification_time"


### PR DESCRIPTION
### New Endpoints
Three API endpoints for loading the Grades page have been developed:

| № | API endpoint | Description | Row format |
| --- |--------------------------------------------------- | --- | ---- |
|  1 | `get_all_course_grades (course_id)` | can be used by course teachers to load the table with all course grades | `{name: str, email: str, grades: List[Optional[int]]}` |
|  2 | `get_student_course_grades(course_id, student_email)` | can be used by course teacher, student, or student's parent to load the table with the detailed information about the grades | `{assignment_name: str, assignment_id: int, grade: Optional[int], comment: Optional[str], grader_name: Optional[str], grader_email: Optional[str]}` |
|  3 | `get_course_assignments(db_cursor, course_id)` | can be used by any course participants, will be used to load the header of the "all grades" table | `{course_id: str, assignment_id: int, creation_time: str, title: str, description: str, author: str}` |

Tests for all new endpoints have been developed in `grades.sh`, new step added to the "Logical curl tests" job 

### File Structure updated with Grades

- new `grades.py` files added to `routers/`, `logic/`, and `/repo` since `submissions` file became too large
- `grade_submission` API moved from `logic/submissions.py` to `logic/grades.py`
- `grade_submission` API moved from `routers/submissions.py` to `routers/grades.py`
- `sql_select_submission_grade` API moved from `repo/grades.py` to `repo/grades.py`
- 
### Other Improvements

- `get_submission` and `get_assignment_submission` now return also `gradedby_name` field