### PR TITLE
Personal Course Information (emoji and course order) added

### DIFF
--- a/backend/constants.py
+++ b/backend/constants.py
@@ -1,1 +1,2 @@
 TIME_FORMAT = "%m-%d-%Y %H:%M:%S"
+EMOJI_COUNT = 80

--- a/backend/constraints.py
+++ b/backend/constraints.py
@@ -86,18 +86,12 @@ def check_course_access(db_cursor, user_email: str, course_id: str) -> bool:
     db_cursor.execute(
         """
         SELECT EXISTS(
-            SELECT 1 FROM courses WHERE instructor = %s AND courseid = %s
-            UNION
-            SELECT 1 FROM teaches WHERE email = %s AND courseid = %s
-            UNION
-            SELECT 1 FROM student_at WHERE email = %s AND courseid = %s
-            UNION
-            SELECT 1 FROM parent_of_at_course WHERE parentemail = %s AND courseid = %s
+            SELECT 1 FROM personal_course_info WHERE email = %s AND courseid = %s
             UNION
             SELECT 1 FROM users WHERE email = %s AND isadmin
         )
     """,
-        (user_email, course_id, user_email, course_id, user_email, course_id, user_email, course_id, user_email),
+        (user_email, course_id, user_email),
     )
     has_access = db_cursor.fetchone()[0]
     return has_access

--- a/backend/json_classes.py
+++ b/backend/json_classes.py
@@ -27,6 +27,7 @@ class Course(CourseID):
     instructor: str
     organization: Optional[str]
     creation_time: str
+    emoji_id: Optional[int]
 
 
 class SectionID(BaseModel):

--- a/backend/logic/courses.py
+++ b/backend/logic/courses.py
@@ -38,7 +38,7 @@ def remove_course(db_conn, db_cursor, course_id: str, user_email: str):
 
 def get_course_info(db_cursor, course_id: str, user_email: str):
     constraints.assert_course_access(db_cursor, user_email, course_id)
-    course = repo.courses.sql_select_course_info(db_cursor, course_id)
+    course = repo.courses.sql_select_course_info(db_cursor, course_id, user_email)
     if not course:
         raise HTTPException(status_code=404, detail="Course not found")
     res = {
@@ -46,6 +46,7 @@ def get_course_info(db_cursor, course_id: str, user_email: str):
         "title": course[1],
         "instructor": course[2],
         "organization": course[3],
-        "creation_time": course[4].strftime(TIME_FORMAT)
+        "creation_time": course[4].strftime(TIME_FORMAT),
+        "emoji_id": course[5],
     }
     return res

--- a/backend/logic/courses.py
+++ b/backend/logic/courses.py
@@ -1,4 +1,4 @@
-from typing import Optional, List
+from typing import Optional
 from fastapi import HTTPException
 from constants import TIME_FORMAT
 import constraints
@@ -49,20 +49,3 @@ def get_course_info(db_cursor, course_id: str, user_email: str):
         "creation_time": course[4].strftime(TIME_FORMAT)
     }
     return res
-
-
-def change_courses_order(db_conn, db_cursor, new_order: List[str], user_email: str):
-    if not isinstance(new_order, list):
-        raise HTTPException(status_code=400, detail="Provided parameter new_order is not a list")
-
-    if not all(isinstance(i, str) for i in new_order):
-        raise HTTPException(status_code=400, detail="Provided parameter new_order is not a list of strings")
-
-    courses = repo.courses.sql_select_available_courses(db_cursor, user_email)
-    if len(new_order) != len(courses) or set(new_order) != set(courses):
-        raise HTTPException(status_code=400, detail="Provided parameter new_order does not match with the list of available courses")
-
-    repo.courses.sql_update_courses_order(db_cursor, new_order, user_email)
-
-    logger.log(db_conn, logger._TAG_COURSE_PERS_INFO_EDIT, f"User {user_email} changed an order of available courses")
-    return {"success": True}

--- a/backend/logic/courses.py
+++ b/backend/logic/courses.py
@@ -1,4 +1,4 @@
-from typing import Optional
+from typing import Optional, List
 from fastapi import HTTPException
 from constants import TIME_FORMAT
 import constraints
@@ -49,3 +49,20 @@ def get_course_info(db_cursor, course_id: str, user_email: str):
         "creation_time": course[4].strftime(TIME_FORMAT)
     }
     return res
+
+
+def change_courses_order(db_conn, db_cursor, new_order: List[str], user_email: str):
+    if not isinstance(new_order, list):
+        raise HTTPException(status_code=400, detail="Provided parameter new_order is not a list")
+
+    if not all(isinstance(i, str) for i in new_order):
+        raise HTTPException(status_code=400, detail="Provided parameter new_order is not a list of strings")
+
+    courses = repo.courses.sql_select_available_courses(db_cursor, user_email)
+    if len(new_order) != len(courses) or set(new_order) != set(courses):
+        raise HTTPException(status_code=400, detail="Provided parameter new_order does not match with the list of available courses")
+
+    repo.courses.sql_update_courses_order(db_cursor, new_order, user_email)
+
+    logger.log(db_conn, logger._TAG_COURSE_PERS_INFO_EDIT, f"User {user_email} changed an order of available courses")
+    return {"success": True}

--- a/backend/logic/logging.py
+++ b/backend/logic/logging.py
@@ -8,7 +8,7 @@ def log(db_conn, tag: str, msg: str):
 
 _TAG_ASSIGNMENT = "assignment"
 _TAG_COURSE = "course"
-_TAG_COURSE_PERS_INFO = "course personal info"
+_TAG_PERSONALIZATION = "personalization"
 _TAG_SECTION = "section"
 _TAG_MATERIAL = "material"
 _TAG_PARENT = "parent"
@@ -35,8 +35,6 @@ TAG_ASSIGNMENT_GRADE = f"{_TAG_ASSIGNMENT} {_ACT_GRADE}"
 
 TAG_COURSE_ADD = f"{_TAG_COURSE} {_ACT_ADD}"
 TAG_COURSE_DEL = f"{_TAG_COURSE} {_ACT_DEL}"
-
-_TAG_COURSE_PERS_INFO_EDIT = f"{_TAG_COURSE_PERS_INFO} {_ACT_EDIT}"
 
 TAG_SECTION_ADD = f"{_TAG_SECTION} {_ACT_ADD}"
 TAG_SECTION_DEL = f"{_TAG_SECTION} {_ACT_DEL}"

--- a/backend/logic/logging.py
+++ b/backend/logic/logging.py
@@ -8,6 +8,7 @@ def log(db_conn, tag: str, msg: str):
 
 _TAG_ASSIGNMENT = "assignment"
 _TAG_COURSE = "course"
+_TAG_COURSE_PERS_INFO = "course personal info"
 _TAG_SECTION = "section"
 _TAG_MATERIAL = "material"
 _TAG_PARENT = "parent"
@@ -34,6 +35,8 @@ TAG_ASSIGNMENT_GRADE = f"{_TAG_ASSIGNMENT} {_ACT_GRADE}"
 
 TAG_COURSE_ADD = f"{_TAG_COURSE} {_ACT_ADD}"
 TAG_COURSE_DEL = f"{_TAG_COURSE} {_ACT_DEL}"
+
+_TAG_COURSE_PERS_INFO_EDIT = f"{_TAG_COURSE_PERS_INFO} {_ACT_EDIT}"
 
 TAG_SECTION_ADD = f"{_TAG_SECTION} {_ACT_ADD}"
 TAG_SECTION_DEL = f"{_TAG_SECTION} {_ACT_DEL}"

--- a/backend/logic/personalization.py
+++ b/backend/logic/personalization.py
@@ -1,0 +1,28 @@
+from typing import List
+from fastapi import HTTPException
+import repo.courses
+import repo.personalization
+import logic.logging as logger
+import constraints
+
+def change_courses_order(db_conn, db_cursor, new_order: List[str], user_email: str):
+    if not isinstance(new_order, list):
+        raise HTTPException(status_code=400, detail="Provided parameter new_order is not a list")
+
+    if not all(isinstance(i, str) for i in new_order):
+        raise HTTPException(status_code=400, detail="Provided parameter new_order is not a list of strings")
+
+    courses = repo.courses.sql_select_available_courses(db_cursor, user_email)
+    if len(new_order) != len(courses) or set(new_order) != set(courses):
+        raise HTTPException(status_code=400, detail="Provided parameter new_order does not match with the list of available courses")
+
+    repo.personalization.sql_update_courses_order(db_cursor, new_order, user_email)
+
+    logger.log(db_conn, logger._TAG_PERSONALIZATION, f"User {user_email} changed an order of available courses")
+    return {"success": True}
+
+def set_course_emoji(db_cursor, course_id: str, emoji_id: int, user_email: str):
+    # checking contraints
+    constraints.assert_course_access(db_cursor, user_email, course_id)
+
+    repo.personalization.sql_set_course_emoji(db_cursor, course_id, emoji_id, user_email)

--- a/backend/logic/personalization.py
+++ b/backend/logic/personalization.py
@@ -21,8 +21,11 @@ def change_courses_order(db_conn, db_cursor, new_order: List[str], user_email: s
     logger.log(db_conn, logger._TAG_PERSONALIZATION, f"User {user_email} changed an order of available courses")
     return {"success": True}
 
-def set_course_emoji(db_cursor, course_id: str, emoji_id: int, user_email: str):
+def set_course_emoji(db_conn, db_cursor, course_id: str, emoji_id: int, user_email: str):
     # checking contraints
     constraints.assert_course_access(db_cursor, user_email, course_id)
 
     repo.personalization.sql_set_course_emoji(db_cursor, course_id, emoji_id, user_email)
+
+    logger.log(db_conn, logger._TAG_PERSONALIZATION, f"User {user_email} set an emoji {emoji_id} for course {course_id}")
+    return {"success": True}

--- a/backend/logic/sections.py
+++ b/backend/logic/sections.py
@@ -26,7 +26,7 @@ def get_course_feed(db_cursor, course_id: str, user_email: str):
 
 
 def create_section(db_conn, db_cursor, course_id: str, title: str, user_email: str):
-    # checking contraints
+    # checking constraints
     constraints.assert_teacher_access(db_cursor, user_email, course_id)
 
     section_id = repo.sections.sql_insert_section(db_cursor, course_id, title)
@@ -36,7 +36,7 @@ def create_section(db_conn, db_cursor, course_id: str, title: str, user_email: s
 
 
 def change_section_order(db_conn, db_cursor, course_id: str, new_order: List[int], user_email: str):
-    # checking contraints
+    # checking constraints
     constraints.assert_teacher_access(db_cursor, user_email, course_id)
 
     if not isinstance(new_order, list):
@@ -56,7 +56,7 @@ def change_section_order(db_conn, db_cursor, course_id: str, new_order: List[int
 
 
 def remove_section(db_conn, db_cursor, course_id: str, section_id: int, user_email: str):
-    # checking contraints
+    # checking constraints
     constraints.assert_teacher_access(db_cursor, user_email, course_id)
     constraints.assert_section_exists(db_cursor, course_id, section_id)
 

--- a/backend/logic/teachers.py
+++ b/backend/logic/teachers.py
@@ -70,9 +70,7 @@ def change_course_instructor(db_conn, db_cursor, course_id: str, teacher_email: 
     constraints.assert_instructor_access(db_cursor, instructor_email, course_id)
     constraints.assert_teacher_access(db_cursor, teacher_email, course_id)
 
-    repo_teachers.sql_delete_teacher(db_cursor, course_id, teacher_email)
-    repo_teachers.sql_insert_teacher(db_cursor, course_id, instructor_email)
-    repo_teachers.sql_update_instructor(db_cursor, course_id, teacher_email)
+    repo_teachers.sql_update_instructor(db_cursor, course_id, instructor_email, teacher_email)
 
     logger.log(db_conn, logger.TAG_INSTRUCTOR_EDIT, f"Course {course_id} now have new instructor {teacher_email} instead of {instructor_email}")
 

--- a/backend/main.py
+++ b/backend/main.py
@@ -13,6 +13,7 @@ import routers.parents
 import routers.students
 import routers.teachers
 import routers.users
+import routers.personalization
 
 
 app = FastAPI(
@@ -38,6 +39,7 @@ app.include_router(routers.assignments.router)
 app.include_router(routers.submissions.router)
 app.include_router(routers.grades.router)
 app.include_router(routers.courses.router)
+app.include_router(routers.personalization.router)
 app.include_router(routers.sections.router)
 app.include_router(routers.materials.router)
 app.include_router(routers.parents.router)

--- a/backend/repo/courses.py
+++ b/backend/repo/courses.py
@@ -5,7 +5,10 @@ from datetime import datetime
 def sql_select_available_courses(db_cursor, user_email: str) -> List[UUID]:
     db_cursor.execute(
         """
-        SELECT courseid FROM personal_course_info WHERE email = %s
+        SELECT courseid
+        FROM personal_course_info
+        WHERE email = %s
+        ORDER BY courseorder ASC
         """,
         (user_email, ),
     )

--- a/backend/repo/courses.py
+++ b/backend/repo/courses.py
@@ -38,7 +38,7 @@ def sql_select_course_info(db_cursor, course_id: str, user_email: str) -> Option
         SELECT c.courseid, c.name, c.instructor, c.organization, c.timecreated, pci.emojiid
         FROM courses c
         LEFT JOIN personal_course_info pci ON c.courseid = pci.courseid AND pci.email = %s
-        WHERE c.courseid = %s::uuid
+        WHERE c.courseid = %s
         """,
         (user_email, course_id),
     )

--- a/backend/repo/courses.py
+++ b/backend/repo/courses.py
@@ -54,7 +54,7 @@ def sql_update_courses_order(db_cursor, new_order: List[str], user_email: str) -
         UPDATE personal_course_info pci
         SET courseorder = new.courseorder
         FROM (VALUES {values_str}) AS new(courseid, courseorder)
-        WHERE pci.email = %s
+        WHERE pci.email = %s AND pci.courseid = new.courseid
         """,
         flat_values + [user_email]
     )

--- a/backend/repo/courses.py
+++ b/backend/repo/courses.py
@@ -54,7 +54,7 @@ def sql_update_courses_order(db_cursor, new_order: List[str], user_email: str) -
         UPDATE personal_course_info pci
         SET courseorder = new.courseorder
         FROM (VALUES {values_str}) AS new(courseid, courseorder)
-        WHERE pci.email = %s AND pci.courseid = new.courseid
+        WHERE pci.email = %s AND pci.courseid = new.courseid::uuid
         """,
         flat_values + [user_email]
     )

--- a/backend/repo/courses.py
+++ b/backend/repo/courses.py
@@ -29,12 +29,13 @@ def sql_delete_course(db_cursor, course_id: str) -> None:
     db_cursor.execute("DELETE FROM courses WHERE courseid = %s", (course_id,))
 
 
-def sql_select_course_info(db_cursor, course_id: str) -> Optional[Tuple[UUID, str, str, Optional[str], datetime]]:
+def sql_select_course_info(db_cursor, course_id: str, user_email: str) -> Optional[Tuple[UUID, str, str, Optional[str], datetime, Optional[int]]]:
     db_cursor.execute(
         """
-        SELECT courseid, name, instructor, organization, timecreated
-        FROM courses
-        WHERE courseid = %s
+        SELECT c.courseid, c.name, c.instructor, c.organization, c.timecreated, psi.emojiid
+        FROM courses c
+        JOIN personal_course_info pci ON c.courseid = pci.courseid
+        WHERE psi.courseid = %s AND pci.email = %s
         """,
         (course_id,),
     )

--- a/backend/repo/courses.py
+++ b/backend/repo/courses.py
@@ -38,7 +38,7 @@ def sql_select_course_info(db_cursor, course_id: str, user_email: str) -> Option
         SELECT c.courseid, c.name, c.instructor, c.organization, c.timecreated, pci.emojiid
         FROM courses c
         LEFT JOIN personal_course_info pci ON c.courseid = pci.courseid AND pci.email = %s
-        WHERE c.courseid = %s
+        WHERE c.courseid = %s::uuid
         """,
         (user_email, course_id),
     )

--- a/backend/repo/courses.py
+++ b/backend/repo/courses.py
@@ -32,11 +32,11 @@ def sql_delete_course(db_cursor, course_id: str) -> None:
 def sql_select_course_info(db_cursor, course_id: str, user_email: str) -> Optional[Tuple[UUID, str, str, Optional[str], datetime, Optional[int]]]:
     db_cursor.execute(
         """
-        SELECT c.courseid, c.name, c.instructor, c.organization, c.timecreated, psi.emojiid
+        SELECT c.courseid, c.name, c.instructor, c.organization, c.timecreated, pci.emojiid
         FROM courses c
-        JOIN personal_course_info pci ON c.courseid = pci.courseid
-        WHERE psi.courseid = %s AND pci.email = %s
+        JOIN personal_course_info pci ON c.courseid = pci.courseid AND pci.email = %s
+        WHERE c.courseid = %s::uuid
         """,
-        (course_id,),
+        (user_email, course_id),
     )
     return db_cursor.fetchone()

--- a/backend/repo/courses.py
+++ b/backend/repo/courses.py
@@ -5,15 +5,9 @@ from datetime import datetime
 def sql_select_available_courses(db_cursor, user_email: str) -> List[UUID]:
     db_cursor.execute(
         """
-        SELECT courseid AS cid FROM courses WHERE instructor = %s
-        UNION
-        SELECT courseid AS cid FROM teaches WHERE email = %s
-        UNION
-        SELECT courseid AS cid FROM student_at WHERE email = %s
-        UNION
-        SELECT courseid AS cid FROM parent_of_at_course WHERE parentemail = %s
+        SELECT courseid FROM personal_course_info WHERE email = %s
         """,
-        (user_email, user_email, user_email, user_email),
+        (user_email, ),
     )
     return [i[0] for i in db_cursor.fetchall()]
 

--- a/backend/repo/courses.py
+++ b/backend/repo/courses.py
@@ -34,7 +34,7 @@ def sql_select_course_info(db_cursor, course_id: str, user_email: str) -> Option
         """
         SELECT c.courseid, c.name, c.instructor, c.organization, c.timecreated, pci.emojiid
         FROM courses c
-        JOIN personal_course_info pci ON c.courseid = pci.courseid AND pci.email = %s
+        LEFT JOIN personal_course_info pci ON c.courseid = pci.courseid AND pci.email = %s
         WHERE c.courseid = %s::uuid
         """,
         (user_email, course_id),

--- a/backend/repo/courses.py
+++ b/backend/repo/courses.py
@@ -39,22 +39,3 @@ def sql_select_course_info(db_cursor, course_id: str) -> Optional[Tuple[UUID, st
         (course_id,),
     )
     return db_cursor.fetchone()
-
-
-def sql_update_courses_order(db_cursor, new_order: List[str], user_email: str) -> None:
-
-    # postpone the checking of uniqueness contraints
-    db_cursor.execute("SET CONSTRAINTS personal_course_info_email_courseorder_key DEFERRED")
-
-    # set correct values
-    values_to_update = [(course_id, index) for index, course_id in enumerate(new_order)]
-    values_str = ", ".join(f"(%s, %s)" for _ in values_to_update)
-    flat_values = [val for pair in values_to_update for val in pair]
-    db_cursor.execute(f"""
-        UPDATE personal_course_info pci
-        SET courseorder = new.courseorder
-        FROM (VALUES {values_str}) AS new(courseid, courseorder)
-        WHERE pci.email = %s AND pci.courseid = new.courseid::uuid
-        """,
-        flat_values + [user_email]
-    )

--- a/backend/repo/personalization.py
+++ b/backend/repo/personalization.py
@@ -13,7 +13,7 @@ def sql_update_courses_order(db_cursor, new_order: List[str], user_email: str) -
         UPDATE personal_course_info pci
         SET courseorder = new.courseorder
         FROM (VALUES {values_str}) AS new(courseid, courseorder)
-        WHERE pci.email = %s AND pci.courseid = new.courseid::uuid
+        WHERE pci.email = %s AND pci.courseid = new.courseid
         """,
         flat_values + [user_email]
     )
@@ -24,7 +24,7 @@ def sql_set_course_emoji(db_cursor, course_id: str, emoji_id: int, user_email: s
         """
         UPDATE personal_course_info
         SET emojiid = %s
-        WHERE email = %s AND courseid = %s::uuid
+        WHERE email = %s AND courseid = %s
         """,
         (emoji_id, user_email, course_id)
     )

--- a/backend/repo/personalization.py
+++ b/backend/repo/personalization.py
@@ -1,0 +1,30 @@
+from typing import List
+
+def sql_update_courses_order(db_cursor, new_order: List[str], user_email: str) -> None:
+
+    # postpone the checking of uniqueness contraints
+    db_cursor.execute("SET CONSTRAINTS personal_course_info_email_courseorder_key DEFERRED")
+
+    # set correct values
+    values_to_update = [(course_id, index) for index, course_id in enumerate(new_order)]
+    values_str = ", ".join(f"(%s, %s)" for _ in values_to_update)
+    flat_values = [val for pair in values_to_update for val in pair]
+    db_cursor.execute(f"""
+        UPDATE personal_course_info pci
+        SET courseorder = new.courseorder
+        FROM (VALUES {values_str}) AS new(courseid, courseorder)
+        WHERE pci.email = %s AND pci.courseid = new.courseid::uuid
+        """,
+        flat_values + [user_email]
+    )
+
+
+def sql_set_course_emoji(db_cursor, course_id: str, emoji_id: int, user_email: str) -> None:
+    db_cursor.execute(
+        """
+        UPDATE personal_course_info
+        SET emojiid = %s
+        WHERE email = %s AND courseid = %s::uuid
+        """,
+        (emoji_id, user_email, course_id)
+    )

--- a/backend/repo/personalization.py
+++ b/backend/repo/personalization.py
@@ -2,7 +2,7 @@ from typing import List
 
 def sql_update_courses_order(db_cursor, new_order: List[str], user_email: str) -> None:
 
-    # postpone the checking of uniqueness contraints
+    # postpone the checking of uniqueness constraints
     db_cursor.execute("SET CONSTRAINTS personal_course_info_email_courseorder_key DEFERRED")
 
     # set correct values

--- a/backend/repo/personalization.py
+++ b/backend/repo/personalization.py
@@ -13,7 +13,7 @@ def sql_update_courses_order(db_cursor, new_order: List[str], user_email: str) -
         UPDATE personal_course_info pci
         SET courseorder = new.courseorder
         FROM (VALUES {values_str}) AS new(courseid, courseorder)
-        WHERE pci.email = %s AND pci.courseid = new.courseid
+        WHERE pci.email = %s AND pci.courseid = new.courseid::uuid
         """,
         flat_values + [user_email]
     )
@@ -24,7 +24,7 @@ def sql_set_course_emoji(db_cursor, course_id: str, emoji_id: int, user_email: s
         """
         UPDATE personal_course_info
         SET emojiid = %s
-        WHERE email = %s AND courseid = %s
+        WHERE email = %s AND courseid = %s::uuid
         """,
         (emoji_id, user_email, course_id)
     )

--- a/backend/repo/sections.py
+++ b/backend/repo/sections.py
@@ -51,6 +51,21 @@ def sql_select_sections(db_cursor, course_id: str) -> List[int]:
 
 
 def sql_update_section_order(db_cursor, course_id: str, new_order: List[int]) -> None:
+
+    # set negative values (to avoid conflicts with UNIQUE)
+    values_to_update = [(section_id, -(index + 1)) for index, section_id in enumerate(new_order)]
+    values_str = ", ".join(f"(%s, %s)" for _ in values_to_update)
+    flat_values = [val for pair in values_to_update for val in pair]
+    db_cursor.execute(f"""
+        UPDATE course_sections cs
+        SET sectionorder = new.sectionorder
+        FROM (VALUES {values_str}) AS new(sectionid, sectionorder)
+        WHERE cs.courseid = %s AND cs.sectionid = new.sectionid
+        """,
+        flat_values + [course_id]
+    )
+
+    # set correct values
     values_to_update = [(section_id, index) for index, section_id in enumerate(new_order)]
     values_str = ", ".join(f"(%s, %s)" for _ in values_to_update)
     flat_values = [val for pair in values_to_update for val in pair]

--- a/backend/repo/sections.py
+++ b/backend/repo/sections.py
@@ -52,7 +52,7 @@ def sql_select_sections(db_cursor, course_id: str) -> List[int]:
 
 def sql_update_section_order(db_cursor, course_id: str, new_order: List[int]) -> None:
 
-    # postpone the checking of uniqueness contraints
+    # postpone the checking of uniqueness constraints
     db_cursor.execute("SET CONSTRAINTS course_sections_courseid_sectionorder_key DEFERRED")
 
     # set correct values

--- a/backend/repo/teachers.py
+++ b/backend/repo/teachers.py
@@ -37,6 +37,6 @@ def sql_update_instructor(db_cursor, course_id: str, old_instructor: str, new_in
     # old instructor is now a "teacher"
     # new instructor is no longer a "teacher"
     db_cursor.execute(
-        "UPDATE teaches SET email = %s WHERE email = %s",
-        (old_instructor, new_instructor),
+        "UPDATE teaches SET email = %s WHERE email = %s AND courseid = %s",
+        (old_instructor, new_instructor, course_id),
     )

--- a/backend/repo/teachers.py
+++ b/backend/repo/teachers.py
@@ -27,8 +27,12 @@ def sql_delete_teacher(db_cursor, course_id: str, removing_teacher_email: str) -
     )
 
 
-def sql_update_instructor(db_cursor, course_id: str, new_instructor: str) -> None:
+def sql_update_instructor(db_cursor, course_id: str, old_instructor: str, new_instructor: str) -> None:
     db_cursor.execute(
         "UPDATE courses SET instructor = %s WHERE courseid = %s",
         (new_instructor, course_id),
+    )
+    db_cursor.execute(
+        "UPDATE teaches SET email = %s WHERE email = %s",
+        (old_instructor, new_instructor),
     )

--- a/backend/repo/teachers.py
+++ b/backend/repo/teachers.py
@@ -28,7 +28,7 @@ def sql_delete_teacher(db_cursor, course_id: str, removing_teacher_email: str) -
 
 
 def sql_update_instructor(db_cursor, course_id: str, old_instructor: str, new_instructor: str) -> None:
-    # set a new instuctor
+    # set a new instructor
     db_cursor.execute(
         "UPDATE courses SET instructor = %s WHERE courseid = %s",
         (new_instructor, course_id),

--- a/backend/repo/teachers.py
+++ b/backend/repo/teachers.py
@@ -28,10 +28,14 @@ def sql_delete_teacher(db_cursor, course_id: str, removing_teacher_email: str) -
 
 
 def sql_update_instructor(db_cursor, course_id: str, old_instructor: str, new_instructor: str) -> None:
+    # set a new instuctor
     db_cursor.execute(
         "UPDATE courses SET instructor = %s WHERE courseid = %s",
         (new_instructor, course_id),
     )
+
+    # old instructor is now a "teacher"
+    # new instructor is no longer a "teacher"
     db_cursor.execute(
         "UPDATE teaches SET email = %s WHERE email = %s",
         (old_instructor, new_instructor),

--- a/backend/routers/courses.py
+++ b/backend/routers/courses.py
@@ -83,3 +83,17 @@ async def get_course_info(course_id: str, user_email: str = Depends(get_current_
     """
     with get_db() as (db_conn, db_cursor):
         return logic.courses.get_course_info(db_cursor, course_id, user_email)
+
+
+@router.post("/change_courses_order", response_model=json_classes.Success, tags=["Courses"])
+async def change_courses_order(
+    new_order: List[str] = Query(...),
+    user_email: str = Depends(get_current_user),
+):
+    """
+    Change the order of courses.
+
+    The list of course_ids should be passed as a new_order parameter.
+    """
+    with get_db() as (db_conn, db_cursor):
+        return logic.courses.change_courses_order(db_conn, db_cursor, new_order, user_email)

--- a/backend/routers/courses.py
+++ b/backend/routers/courses.py
@@ -83,17 +83,3 @@ async def get_course_info(course_id: str, user_email: str = Depends(get_current_
     """
     with get_db() as (db_conn, db_cursor):
         return logic.courses.get_course_info(db_cursor, course_id, user_email)
-
-
-@router.post("/change_courses_order", response_model=json_classes.Success, tags=["Courses"])
-async def change_courses_order(
-    new_order: List[str] = Query(...),
-    user_email: str = Depends(get_current_user),
-):
-    """
-    Change the order of courses.
-
-    The list of course_ids should be passed as a new_order parameter.
-    """
-    with get_db() as (db_conn, db_cursor):
-        return logic.courses.change_courses_order(db_conn, db_cursor, new_order, user_email)

--- a/backend/routers/courses.py
+++ b/backend/routers/courses.py
@@ -75,7 +75,9 @@ async def remove_course(course_id: str, user_email: str = Depends(get_current_us
 @router.get("/get_course_info", response_model=json_classes.Course, tags=["Courses"])
 async def get_course_info(course_id: str, user_email: str = Depends(get_current_user)):
     """
-    Get information about the course: course_id, title, instructor, organization, and creation date.
+    Get information about the course: course_id, title, instructor, organization, creation date, and personal emoji_id.
+
+    emoji_id is optional (can be None).
 
     Organization can be None.
 

--- a/backend/routers/personalization.py
+++ b/backend/routers/personalization.py
@@ -23,7 +23,7 @@ async def change_courses_order(
         return logic.personalization.change_courses_order(db_conn, db_cursor, new_order, user_email)
 
 
-@router.post("/set_course_emoji", response_model=json_classes.Course, tags=["Personalization"])
+@router.post("/set_course_emoji", response_model=json_classes.Success, tags=["Personalization"])
 async def set_course_emoji(
     course_id: str,
     emoji_id: int = Query(..., ge=0, le=EMOJI_COUNT),
@@ -35,4 +35,4 @@ async def set_course_emoji(
     Course role (Primary Instructor, Teacher, Student, Parent) required.
     """
     with get_db() as (db_conn, db_cursor):
-        return logic.personalization.set_course_emoji(db_cursor, course_id, emoji_id, user_email)
+        return logic.personalization.set_course_emoji(db_conn, db_cursor, course_id, emoji_id, user_email)

--- a/backend/routers/personalization.py
+++ b/backend/routers/personalization.py
@@ -1,0 +1,38 @@
+from typing import List
+from fastapi import APIRouter, Query, Depends
+from auth import get_current_user, get_db
+import json_classes
+import logic.personalization
+from constants import EMOJI_COUNT
+
+
+router = APIRouter()
+
+
+@router.post("/change_courses_order", response_model=json_classes.Success, tags=["Personalization"])
+async def change_courses_order(
+    new_order: List[str] = Query(...),
+    user_email: str = Depends(get_current_user),
+):
+    """
+    Change the order of courses.
+
+    The list of course_ids should be passed as a new_order parameter.
+    """
+    with get_db() as (db_conn, db_cursor):
+        return logic.personalization.change_courses_order(db_conn, db_cursor, new_order, user_email)
+
+
+@router.post("/set_course_emoji", response_model=json_classes.Course, tags=["Personalization"])
+async def set_course_emoji(
+    course_id: str,
+    emoji_id: int = Query(..., ge=0, le=EMOJI_COUNT),
+    user_email: str = Depends(get_current_user)
+):
+    """
+    Set a personal emoji for a course.
+
+    Course role (Primary Instructor, Teacher, Student, Parent) required.
+    """
+    with get_db() as (db_conn, db_cursor):
+        return logic.personalization.set_course_emoji(db_cursor, course_id, emoji_id, user_email)

--- a/backend/tests/courses.sh
+++ b/backend/tests/courses.sh
@@ -82,6 +82,12 @@ json_exact_match_test "Get Alice's role in course Math" "$info" "$expected" "is_
 
 # --------------------------------------------------------------------
 
+success_test "Set course emoji" \
+    -X POST "$API_URL/set_course_emoji?course_id=$noorgcourseid&emoji_id=1" \
+    -H "Authorization: Bearer $TOKEN" \
+
+# --------------------------------------------------------------------
+
 info=$(curl -s -X GET \
     -H "Authorization: Bearer $TOKEN" \
     "$API_URL/get_course_info?course_id=$mathcourseid")

--- a/backend/tests/courses.sh
+++ b/backend/tests/courses.sh
@@ -83,7 +83,7 @@ json_exact_match_test "Get Alice's role in course Math" "$info" "$expected" "is_
 # --------------------------------------------------------------------
 
 success_test "Set course emoji" \
-    -X POST "$API_URL/set_course_emoji?course_id=$noorgcourseid&emoji_id=1" \
+    -X POST "$API_URL/set_course_emoji?course_id=$mathcourseid&emoji_id=1" \
     -H "Authorization: Bearer $TOKEN" \
 
 # --------------------------------------------------------------------

--- a/backend/tests/courses.sh
+++ b/backend/tests/courses.sh
@@ -314,6 +314,25 @@ json_exact_match_test "Request the list of available courses from Alice" "$cours
 
 # --------------------------------------------------------------------
 
+success_test "Change the order of available courses by Alice" \
+    -X POST "$API_URL/change_courses_order?new_order=$engcourseid&new_order=$mathcourseid" \
+    -H "Authorization: Bearer $TOKEN" \
+
+# --------------------------------------------------------------------
+
+courses=$(curl -s -X GET \
+    -H "Authorization: Bearer $TOKEN" \
+    "$API_URL/available_courses")
+
+expected='[
+    {"course_id":"'"$engcourseid"'"},
+    {"course_id":"'"$mathcourseid"'"}
+]'
+
+json_exact_match_test "Request the list of available courses from Alice" "$courses" "$expected" "course_id"
+
+# --------------------------------------------------------------------
+
 courses=$(curl -s -X GET \
     -H "Authorization: Bearer $TOKEN" \
     "$API_URL/get_instructor_courses")

--- a/backend/tests/courses.sh
+++ b/backend/tests/courses.sh
@@ -86,6 +86,14 @@ success_test "Set course emoji" \
     -X POST "$API_URL/set_course_emoji?course_id=$mathcourseid&emoji_id=1" \
     -H "Authorization: Bearer $TOKEN" \
 
+fail_test "Set course emoji with too large ID" \
+    -X POST "$API_URL/set_course_emoji?course_id=$mathcourseid&emoji_id=10000" \
+    -H "Authorization: Bearer $TOKEN" \
+
+fail_test "Set course emoji with negative ID" \
+    -X POST "$API_URL/set_course_emoji?course_id=$mathcourseid&emoji_id=-10" \
+    -H "Authorization: Bearer $TOKEN" \
+
 # --------------------------------------------------------------------
 
 info=$(curl -s -X GET \
@@ -322,6 +330,10 @@ json_exact_match_test "Request the list of available courses from Alice" "$cours
 
 success_test "Change the order of available courses by Alice" \
     -X POST "$API_URL/change_courses_order?new_order=$engcourseid&new_order=$mathcourseid" \
+    -H "Authorization: Bearer $TOKEN" \
+
+fail_test "Request to change the order of courses to repeating ones by Alice" \
+    -X POST "$API_URL/change_courses_order?new_order=$mathcourseid&new_order=$mathcourseid" \
     -H "Authorization: Bearer $TOKEN" \
 
 # --------------------------------------------------------------------

--- a/backend/tests/courses.sh
+++ b/backend/tests/courses.sh
@@ -93,7 +93,7 @@ info=$(curl -s -X GET \
     "$API_URL/get_course_info?course_id=$mathcourseid")
 
 expected='
-    {"course_id":"'"$mathcourseid"'","title":"Math","instructor":"alice@example.com","organization":"Innopolis University"}
+    {"course_id":"'"$mathcourseid"'","title":"Math","instructor":"alice@example.com","organization":"Innopolis University","emoji_id":1}
 '
 
 json_partial_match_test "Request the course info from Alice" "$info" "$expected" "course_id" "creation_time"

--- a/backend/tests/dbreset.sh
+++ b/backend/tests/dbreset.sh
@@ -15,7 +15,8 @@ docker exec -i system_db psql -U postgres -d edhub -v ON_ERROR_STOP=1 -c "
     logs,
     material_files,
     assignment_files,
-    submissions_files
+    submissions_files,
+    personal_course_info
   RESTART IDENTITY CASCADE;
 "
 

--- a/database/system/initialize.sql
+++ b/database/system/initialize.sql
@@ -159,8 +159,7 @@ CREATE INDEX idx_logs_t ON logs(t);
 
 CREATE TABLE emoji(
     id serial PRIMARY KEY,
-    name text NOT NULL CHECK (length(name) <= 80),
-    fileid uuid
+    name text NOT NULL CHECK (length(name) <= 80)
 );
 
 CREATE TABLE personal_course_info(
@@ -222,10 +221,11 @@ BEGIN
     END CASE;
 
     IF (TG_OP = 'INSERT') THEN
-        INSERT INTO personal_course_info (courseid, email, courseorder)
+        INSERT INTO personal_course_info (courseid, email, emojiid, courseorder)
         VALUES (
             v_courseid,
             v_email,
+            (SELECT id FROM emoji ORDER BY random() LIMIT 1),
             COALESCE(
                 (SELECT MAX(courseorder) + 1
                  FROM personal_course_info

--- a/database/system/initialize.sql
+++ b/database/system/initialize.sql
@@ -23,7 +23,9 @@ CREATE TABLE course_sections(
     name text NOT NULL CHECK (length(name) BETWEEN 3 AND 80),
     sectionorder int NOT NULL CHECK (sectionorder >= 0),
     PRIMARY KEY (courseid, sectionid),
-    UNIQUE (courseid, sectionorder)
+    CONSTRAINT course_sections_courseid_sectionorder_key
+        UNIQUE (courseid, sectionorder)
+        DEFERRABLE INITIALLY IMMEDIATE
 );
 
 CREATE TABLE course_materials(
@@ -67,12 +69,19 @@ CREATE TABLE course_assignments_submissions(
 CREATE TABLE teaches(
     email text REFERENCES users ON DELETE CASCADE,
     courseid uuid REFERENCES courses ON DELETE CASCADE,
+    emojiid int NULL REFERENCES emoji(id) ON DELETE SET NULL,
+    courseorder int NOT NULL CHECK (courseorder >= 0),
+    UNIQUE (email, courseorder),
     PRIMARY KEY (email, courseid)
 );
 
 CREATE TABLE student_at(
     email text REFERENCES users ON DELETE CASCADE,
     courseid uuid REFERENCES courses ON DELETE CASCADE,
+    emojiid int NULL REFERENCES emoji(id) ON DELETE SET NULL,
+    courseorder int NOT NULL CHECK (courseorder >= 0),
+    grade int NULL,
+    UNIQUE (email, courseorder),
     PRIMARY KEY (email, courseid)
 );
 
@@ -80,6 +89,9 @@ CREATE TABLE parent_of_at_course(
     parentemail text REFERENCES users ON DELETE CASCADE,
     studentemail text REFERENCES users ON DELETE CASCADE,
     courseid uuid REFERENCES courses ON DELETE CASCADE,
+    emojiid int NULL REFERENCES emoji(id) ON DELETE SET NULL,
+    courseorder int NOT NULL CHECK (courseorder >= 0),
+    UNIQUE (email, courseorder),
     FOREIGN KEY (studentemail, courseid) REFERENCES student_at ON DELETE CASCADE,
     PRIMARY KEY (parentemail, studentemail, courseid)
 );
@@ -119,6 +131,13 @@ CREATE TABLE submissions_files(
     uploadtime timestamp NOT NULL,
     FOREIGN KEY (courseid, assid, email) REFERENCES course_assignments_submissions ON DELETE CASCADE,
     PRIMARY KEY (courseid, assid, email, fileid)
+);
+
+CREATE TABLE emoji(
+    id serial NOT NULL,
+    name text NOT NULL CHECK (length(filename) <= 80),
+    fileid uuid,
+    PRIMARY KEY (id)
 );
 
 CREATE OR REPLACE FUNCTION create_default_section() RETURNS trigger AS $$

--- a/database/system/initialize.sql
+++ b/database/system/initialize.sql
@@ -22,7 +22,8 @@ CREATE TABLE course_sections(
     sectionid serial NOT NULL,
     name text NOT NULL CHECK (length(name) BETWEEN 3 AND 80),
     sectionorder int NOT NULL CHECK (sectionorder >= 0),
-    PRIMARY KEY (courseid, sectionid)
+    PRIMARY KEY (courseid, sectionid),
+    UNIQUE (courseid, sectionorder)
 );
 
 CREATE TABLE course_materials(

--- a/database/system/initialize.sql
+++ b/database/system/initialize.sql
@@ -154,18 +154,12 @@ CREATE INDEX idx_parent_course_student ON parent_of_at_course(courseid, studente
 CREATE INDEX idx_parent_course_parent ON parent_of_at_course(courseid, parentemail);
 CREATE INDEX idx_logs_t ON logs(t);
 
-
 -------------- PERSONAL COURSE INFO --------------
-
-CREATE TABLE emoji(
-    id serial PRIMARY KEY,
-    name text NOT NULL CHECK (length(name) <= 80)
-);
 
 CREATE TABLE personal_course_info(
     courseid uuid REFERENCES courses ON DELETE CASCADE,
     email text REFERENCES users ON DELETE CASCADE,
-    emojiid int NULL REFERENCES emoji(id) ON DELETE SET NULL,
+    emojiid int NULL CHECK (emojiid BETWEEN 0 AND 80),
     courseorder int NOT NULL CHECK (courseorder >= 0),
     PRIMARY KEY (courseid, email),
     CONSTRAINT personal_course_info_email_courseorder_key
@@ -225,7 +219,7 @@ BEGIN
         VALUES (
             v_courseid,
             v_email,
-            (SELECT id FROM emoji ORDER BY random() LIMIT 1),
+            floor(random() * (80 + 1))::integer,
             COALESCE(
                 (SELECT MAX(courseorder) + 1
                  FROM personal_course_info

--- a/database/system/initialize.sql
+++ b/database/system/initialize.sql
@@ -158,10 +158,9 @@ CREATE INDEX idx_logs_t ON logs(t);
 -------------- PERSONAL COURSE INFO --------------
 
 CREATE TABLE emoji(
-    id serial NOT NULL,
-    name text NOT NULL CHECK (length(filename) <= 80),
-    fileid uuid,
-    PRIMARY KEY (id)
+    id serial PRIMARY KEY,
+    name text NOT NULL CHECK (length(name) <= 80),
+    fileid uuid
 );
 
 CREATE TABLE personal_course_info(

--- a/database/system/initialize.sql
+++ b/database/system/initialize.sql
@@ -69,19 +69,12 @@ CREATE TABLE course_assignments_submissions(
 CREATE TABLE teaches(
     email text REFERENCES users ON DELETE CASCADE,
     courseid uuid REFERENCES courses ON DELETE CASCADE,
-    emojiid int NULL REFERENCES emoji(id) ON DELETE SET NULL,
-    courseorder int NOT NULL CHECK (courseorder >= 0),
-    UNIQUE (email, courseorder),
     PRIMARY KEY (email, courseid)
 );
 
 CREATE TABLE student_at(
     email text REFERENCES users ON DELETE CASCADE,
     courseid uuid REFERENCES courses ON DELETE CASCADE,
-    emojiid int NULL REFERENCES emoji(id) ON DELETE SET NULL,
-    courseorder int NOT NULL CHECK (courseorder >= 0),
-    grade int NULL,
-    UNIQUE (email, courseorder),
     PRIMARY KEY (email, courseid)
 );
 
@@ -89,9 +82,6 @@ CREATE TABLE parent_of_at_course(
     parentemail text REFERENCES users ON DELETE CASCADE,
     studentemail text REFERENCES users ON DELETE CASCADE,
     courseid uuid REFERENCES courses ON DELETE CASCADE,
-    emojiid int NULL REFERENCES emoji(id) ON DELETE SET NULL,
-    courseorder int NOT NULL CHECK (courseorder >= 0),
-    UNIQUE (email, courseorder),
     FOREIGN KEY (studentemail, courseid) REFERENCES student_at ON DELETE CASCADE,
     PRIMARY KEY (parentemail, studentemail, courseid)
 );
@@ -131,13 +121,6 @@ CREATE TABLE submissions_files(
     uploadtime timestamp NOT NULL,
     FOREIGN KEY (courseid, assid, email) REFERENCES course_assignments_submissions ON DELETE CASCADE,
     PRIMARY KEY (courseid, assid, email, fileid)
-);
-
-CREATE TABLE emoji(
-    id serial NOT NULL,
-    name text NOT NULL CHECK (length(filename) <= 80),
-    fileid uuid,
-    PRIMARY KEY (id)
 );
 
 CREATE OR REPLACE FUNCTION create_default_section() RETURNS trigger AS $$

--- a/database/system/initialize.sql
+++ b/database/system/initialize.sql
@@ -211,13 +211,12 @@ BEGIN
                  WHERE email = v_email),
                 0
             )
-        )
+        );
         RETURN NEW;
 
     ELSIF (TG_OP = 'DELETE') THEN
         DELETE FROM personal_course_info
         WHERE courseid = v_courseid AND email = v_email;
-
         RETURN OLD;
     END IF;
     RETURN NULL;

--- a/database/system/initialize.sql
+++ b/database/system/initialize.sql
@@ -1,6 +1,8 @@
 CREATE DATABASE edhub;
 \c edhub
 
+-------------- MAIN TABLES --------------
+
 CREATE TABLE users(
     email text PRIMARY KEY CHECK (length(email) <= 254),
     publicname text NOT NULL CHECK (length(publicname) <= 80),
@@ -136,6 +138,8 @@ CREATE TRIGGER courses_default_section_trigger
     FOR EACH ROW
     EXECUTE PROCEDURE create_default_section();
 
+-------------- INDEXES --------------
+
 CREATE INDEX idx_users_isadmin_true ON users(isadmin) WHERE isadmin = true;
 CREATE INDEX idx_courses_instructor ON courses(instructor);
 CREATE INDEX idx_materials_course_time ON course_materials(courseid, timeadded);
@@ -149,3 +153,92 @@ CREATE INDEX idx_student_at_course ON student_at(courseid);
 CREATE INDEX idx_parent_course_student ON parent_of_at_course(courseid, studentemail);
 CREATE INDEX idx_parent_course_parent ON parent_of_at_course(courseid, parentemail);
 CREATE INDEX idx_logs_t ON logs(t);
+
+
+-------------- PERSONAL COURSE INFO --------------
+
+CREATE TABLE emoji(
+    id serial NOT NULL,
+    name text NOT NULL CHECK (length(filename) <= 80),
+    fileid uuid,
+    PRIMARY KEY (id)
+);
+
+CREATE TABLE personal_course_info(
+    courseid uuid REFERENCES courses ON DELETE CASCADE,
+    email text REFERENCES users ON DELETE CASCADE,
+    emojiid int NULL REFERENCES emoji(id) ON DELETE SET NULL,
+    courseorder int NOT NULL CHECK (courseorder >= 0),
+    PRIMARY KEY (courseid, email),
+    CONSTRAINT personal_course_info_email_courseorder_key
+        UNIQUE (email, courseorder)
+        DEFERRABLE INITIALLY IMMEDIATE
+);
+
+CREATE OR REPLACE FUNCTION trg_personal_course_info()
+RETURNS trigger AS $$
+DECLARE
+    v_email text;
+    v_courseid uuid;
+BEGIN
+    CASE TG_TABLE_NAME
+        WHEN 'student_at' THEN
+            v_email := COALESCE(NEW.email, OLD.email);
+            v_courseid := COALESCE(NEW.courseid, OLD.courseid);
+
+        WHEN 'teaches' THEN
+            v_email := COALESCE(NEW.email, OLD.email);
+            v_courseid := COALESCE(NEW.courseid, OLD.courseid);
+
+        WHEN 'parent_of_at_course' THEN
+            v_email := COALESCE(NEW.parentemail, OLD.parentemail);
+            v_courseid := COALESCE(NEW.courseid, OLD.courseid);
+
+        WHEN 'courses' THEN
+            v_email := COALESCE(NEW.instructor, OLD.instructor);
+            v_courseid := COALESCE(NEW.courseid, OLD.courseid);
+        ELSE
+            RAISE EXCEPTION 'Unsupported table: %', TG_TABLE_NAME;
+    END CASE;
+
+    IF (TG_OP = 'INSERT') THEN
+        INSERT INTO personal_course_info (courseid, email, courseorder)
+        VALUES (
+            v_courseid,
+            v_email,
+            COALESCE(
+                (SELECT MAX(courseorder) + 1
+                 FROM personal_course_info
+                 WHERE email = v_email),
+                0
+            )
+        )
+        ON CONFLICT DO NOTHING;
+        RETURN NEW;
+
+    ELSIF (TG_OP = 'DELETE') THEN
+        DELETE FROM personal_course_info
+        WHERE courseid = v_courseid AND email = v_email;
+
+        RETURN OLD;
+    END IF;
+    RETURN NULL;
+END;
+$$ LANGUAGE plpgsql;
+
+
+CREATE TRIGGER trg_student_info
+    AFTER INSERT OR DELETE ON student_at
+    FOR EACH ROW EXECUTE FUNCTION trg_personal_course_info();
+
+CREATE TRIGGER trg_teacher_info
+    AFTER INSERT OR DELETE ON teaches
+    FOR EACH ROW EXECUTE FUNCTION trg_personal_course_info();
+
+CREATE TRIGGER trg_parent_info
+    AFTER INSERT OR DELETE ON parent_of_at_course
+    FOR EACH ROW EXECUTE FUNCTION trg_personal_course_info();
+
+CREATE TRIGGER trg_instructor_info
+    AFTER INSERT OR DELETE ON courses
+    FOR EACH ROW EXECUTE FUNCTION trg_personal_course_info();

--- a/database/system/initialize.sql
+++ b/database/system/initialize.sql
@@ -212,7 +212,6 @@ BEGIN
                 0
             )
         )
-        ON CONFLICT DO NOTHING;
         RETURN NEW;
 
     ELSIF (TG_OP = 'DELETE') THEN


### PR DESCRIPTION
## Feature Description
A new table `personal_course_info` has been added to the database to contain the personal course settings for each user. 
- any user can now set up a course emoji via the `emojiid` field
  - by default, a course emoji is randomly generated when the coruse is created
- any user can now arrange courses on the main page and organize them via the `courseorder` field
  - by default, a course added to the end of available courses

## Database Updates

### New `personal_course_info` table created

```sql
CREATE TABLE personal_course_info(
    courseid uuid REFERENCES courses ON DELETE CASCADE,
    email text REFERENCES users ON DELETE CASCADE,
    emojiid int NULL CHECK (emojiid BETWEEN 0 AND 80),
    courseorder int NOT NULL CHECK (courseorder >= 0),
    PRIMARY KEY (courseid, email),
    CONSTRAINT personal_course_info_email_courseorder_key
        UNIQUE (email, courseorder)
        DEFERRABLE INITIALLY IMMEDIATE
);
```

### INSERT and DELETE triggers added
To keep the table `personal_course_info` consistent, I developed the triggers on insert and delete within the tables `student_at`, `teaches`, `courses`, and `parent_of_at_course`.

The table `parent_of_at_course` triggered only inserting of the first row with provided `parentemail` and deleting the last row with provided `parentemail` (to avoid conflicts when adding / removing several children).
```sql
CREATE OR REPLACE FUNCTION trg_personal_course_info()
RETURNS trigger AS $$
DECLARE
    v_email text;
    v_courseid uuid;
BEGIN
    CASE TG_TABLE_NAME
        WHEN 'student_at' THEN
            v_email := COALESCE(NEW.email, OLD.email);
            v_courseid := COALESCE(NEW.courseid, OLD.courseid);

        WHEN 'teaches' THEN
            v_email := COALESCE(NEW.email, OLD.email);
            v_courseid := COALESCE(NEW.courseid, OLD.courseid);
        
        WHEN 'courses' THEN
            v_email := COALESCE(NEW.instructor, OLD.instructor);
            v_courseid := COALESCE(NEW.courseid, OLD.courseid);

        WHEN 'parent_of_at_course' THEN
            IF TG_OP = 'DELETE' THEN
                IF (SELECT COUNT(*) 
                    FROM parent_of_at_course
                    WHERE parentemail = COALESCE(OLD.parentemail, NEW.parentemail)
                    AND courseid = COALESCE(OLD.courseid, NEW.courseid)
                ) > 0 THEN
                    RETURN NULL;
                END IF;
            END IF;

            IF TG_OP = 'INSERT' THEN
                IF (SELECT COUNT(*) 
                    FROM parent_of_at_course
                    WHERE parentemail = COALESCE(NEW.parentemail, OLD.parentemail)
                    AND courseid = COALESCE(NEW.courseid, OLD.courseid)
                ) > 1 THEN
                    RETURN NULL;
                END IF;
            END IF;

            v_email := COALESCE(NEW.parentemail, OLD.parentemail);
            v_courseid := COALESCE(NEW.courseid, OLD.courseid);

        ELSE
            RAISE EXCEPTION 'Unsupported table: %', TG_TABLE_NAME;
    END CASE;

    IF (TG_OP = 'INSERT') THEN
        INSERT INTO personal_course_info (courseid, email, emojiid, courseorder)
        VALUES (
            v_courseid,
            v_email,
            floor(random() * (80 + 1))::integer,
            COALESCE(
                (SELECT MAX(courseorder) + 1
                 FROM personal_course_info
                 WHERE email = v_email),
                0
            )
        );
        RETURN NEW;

    ELSIF (TG_OP = 'DELETE') THEN
        DELETE FROM personal_course_info
        WHERE courseid = v_courseid AND email = v_email;
        RETURN OLD;
    END IF;
    RETURN NULL;
END;
$$ LANGUAGE plpgsql;


CREATE TRIGGER trg_student_info
    AFTER INSERT OR DELETE ON student_at
    FOR EACH ROW EXECUTE FUNCTION trg_personal_course_info();

CREATE TRIGGER trg_teacher_info
    AFTER INSERT OR DELETE ON teaches
    FOR EACH ROW EXECUTE FUNCTION trg_personal_course_info();

CREATE TRIGGER trg_parent_info
    AFTER INSERT OR DELETE ON parent_of_at_course
    FOR EACH ROW EXECUTE FUNCTION trg_personal_course_info();

CREATE TRIGGER trg_instructor_info
    AFTER INSERT OR DELETE ON courses
    FOR EACH ROW EXECUTE FUNCTION trg_personal_course_info();
```

## Developed endpoints
- `change_courses_order(new_order: List[str])` that accepts the list of available courses in the desired order and set it
- `set_course_emoji(course_id: str, emoji_id: int)` that set the personal emoji to some course

## Changed endpoints
- `get_course_info` now returns also the `emojiid: Optional[int]` as the personal course emoji
  - administrator that is not a course member will receive Null
- `change_course_instructor` now uses a single `sql_update_instructor` function that updates the `instructor` field in `courses` table and the `email` field in the `teaches` table
  - inserting and deleting the course teachers (as it was implemented previously) will trigger the changes in the `personal_course_info` table that will reset the `courseorder` and `emojiid`
  - suggested approach with `update` will not trigger the change of `personal_course_info`

## Other Issues Resolved
- `available_courses` now checks just `personal_course_info` (for course access);
- `check_course_access` now checks just `personal_course_info` (for course access) and `users` (for admin access);
- `course_sections` now has a `UNIQUE (courseid, sectionorder)` restriction that was successfully implemented by the **DEFERRED CONSTRAINTS** feature